### PR TITLE
Add support for multi-session ORM instances over a single connection

### DIFF
--- a/src/query/batch.ts
+++ b/src/query/batch.ts
@@ -1,4 +1,4 @@
-import type { Surreal } from "surrealdb";
+import type { SurrealSession } from "surrealdb";
 import type { DisplayContext } from "../utils/display.ts";
 import { displayContext } from "../utils/display.ts";
 import { __display } from "../utils/workable.ts";
@@ -20,7 +20,7 @@ export type BatchResult<Q extends Query<any, any>[]> = {
 // biome-ignore lint/suspicious/noExplicitAny: required for generic constraint flexibility
 export class BatchQuery<Q extends Query<any, any>[]> {
 	constructor(
-		private readonly surreal: Surreal,
+		private readonly surreal: SurrealSession,
 		private readonly queries: Q,
 	) {}
 

--- a/src/query/transaction.ts
+++ b/src/query/transaction.ts
@@ -1,4 +1,4 @@
-import type { Surreal, SurrealTransaction } from "surrealdb";
+import type { SurrealSession, SurrealTransaction } from "surrealdb";
 import type { CreateSchemaLookup } from "../schema/lookup.ts";
 import { type AnyTable, type MappedTables, Orm } from "../schema/orm.ts";
 
@@ -17,10 +17,10 @@ export class Transaction<T extends AnyTable[] = AnyTable[]> extends Orm<T> {
 		tables: MappedTables<T>,
 		lookup: CreateSchemaLookup<T>,
 	) {
-		// Cast SurrealTransaction as Surreal — safe because the only method
-		// Query.execute() calls on it is .query(), which both Surreal and
+		// Cast SurrealTransaction as SurrealSession — safe because the only method
+		// Query.execute() calls on it is .query(), which both SurrealSession and
 		// SurrealTransaction inherit from SurrealQueryable.
-		super(transaction as unknown as Surreal, tables, lookup);
+		super(transaction as unknown as SurrealSession, tables, lookup);
 		this._transaction = transaction;
 	}
 

--- a/src/schema/orm.ts
+++ b/src/schema/orm.ts
@@ -1,4 +1,4 @@
-import type { Surreal } from "surrealdb";
+import type { SurrealSession } from "surrealdb";
 import { RecordId, type RecordIdValue } from "surrealdb";
 import type { Query } from "../query/abstract";
 import { BatchQuery } from "../query/batch";
@@ -26,7 +26,7 @@ export type MappedTables<T extends AnyTable[]> = {
 
 export class Orm<T extends AnyTable[] = AnyTable[]> {
 	constructor(
-		public readonly surreal: Surreal,
+		public readonly surreal: SurrealSession,
 		public readonly tables: MappedTables<T>,
 		public readonly lookup: CreateSchemaLookup<T>,
 	) {}
@@ -279,7 +279,10 @@ export class Orm<T extends AnyTable[] = AnyTable[]> {
 	}
 }
 
-export function orm<T extends AnyTable[]>(surreal: Surreal, ...tables: T) {
+export function orm<T extends AnyTable[]>(
+	surreal: SurrealSession,
+	...tables: T
+) {
 	const mapped = tables.reduce<MappedTables<T>>(
 		(acc, table) => {
 			const key = table.tb as T[number]["tb"];


### PR DESCRIPTION
## Summary

Adds support for creating multiple ORM instances scoped to different sessions over a single connection. Each session can have its own namespace, database, authentication state, and variables - useful for multi-tenant architectures, per-request auth scoping, and working across multiple databases simultaneously.