### PR TITLE
Add `and()` + `or()` combiners for compound `WHERE` conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -692,6 +692,44 @@ db.select("user").where((user) =>
 );
 ```
 
+### Compound conditions
+
+For complex conditions, use the standalone `and()` and `or()` combiners. These make precedence explicit and produce correctly parenthesized SurrealQL:
+
+```typescript
+import { orm, table, t, and, or } from "surqlize";
+
+// Simple compound: age >= 18 AND email ends with @example.com
+db.select("user").where((user) =>
+  and(user.age.gte(18), user.email.endsWith("@example.com"))
+);
+// WHERE (age >= 18 AND string::ends_with(email, "@example.com"))
+
+// OR with multiple options
+db.select("user").where((user) =>
+  or(user.role.eq("admin"), user.role.eq("moderator"), user.role.eq("owner"))
+);
+// WHERE (role = "admin" OR role = "moderator" OR role = "owner")
+
+// Nested: AND with inner OR for grouped conditions
+db.select("user").where((user) =>
+  and(
+    user.age.gte(18),
+    or(user.role.eq("admin"), user.role.eq("moderator")),
+    user.email.endsWith("@example.com"),
+  )
+);
+// WHERE (age >= 18 AND (role = "admin" OR role = "moderator") AND string::ends_with(email, "@example.com"))
+
+// Chaining .and() / .or() on individual conditions also works
+db.select("user").where((user) =>
+  user.age.gte(18).and(user.name.first.eq("Alice"))
+);
+// WHERE (age >= 18 AND name.first = "Alice")
+```
+
+Both `and()` and `or()` require at least two conditions and accept any number of additional conditions. Nesting them produces correctly parenthesized output, so precedence is always explicit.
+
 ## Type-specific functions
 
 ### String functions

--- a/src/functions/filters.ts
+++ b/src/functions/filters.ts
@@ -51,7 +51,7 @@ export function joiningFilter<C extends WorkableContext>(
 		[__ctx]: ctx,
 		[__type]: t.bool(),
 		[__display](ctx) {
-			return params.map((p) => p[__display](ctx)).join(` ${kind} `);
+			return `(${params.map((p) => p[__display](ctx)).join(` ${kind} `)})`;
 		},
 	});
 }

--- a/src/functions/standalone/and.ts
+++ b/src/functions/standalone/and.ts
@@ -1,0 +1,11 @@
+import type { BoolType } from "../../types";
+import { __ctx, type Workable, type WorkableContext } from "../../utils";
+import type { Actionable } from "../../utils/actionable";
+import { joiningFilter } from "../filters";
+
+/** and(...conditions) - combine multiple conditions with AND */
+export function and<C extends WorkableContext>(
+	...conditions: [Workable<C>, Workable<C>, ...Workable<C>[]]
+): Actionable<C, BoolType> {
+	return joiningFilter(conditions[0][__ctx], "AND", ...conditions);
+}

--- a/src/functions/standalone/index.ts
+++ b/src/functions/standalone/index.ts
@@ -68,6 +68,7 @@ export function standaloneConst<
 	});
 }
 
+export * from "./and";
 export * from "./bytes";
 export * from "./count";
 export * from "./crypto";
@@ -79,6 +80,7 @@ export * from "./math";
 export * from "./meta";
 export * from "./not";
 export * from "./object";
+export * from "./or";
 export * from "./parse";
 export * from "./rand";
 export * from "./search";

--- a/src/functions/standalone/or.ts
+++ b/src/functions/standalone/or.ts
@@ -1,0 +1,11 @@
+import type { BoolType } from "../../types";
+import { __ctx, type Workable, type WorkableContext } from "../../utils";
+import type { Actionable } from "../../utils/actionable";
+import { joiningFilter } from "../filters";
+
+/** or(...conditions) - combine multiple conditions with OR */
+export function or<C extends WorkableContext>(
+	...conditions: [Workable<C>, Workable<C>, ...Workable<C>[]]
+): Actionable<C, BoolType> {
+	return joiningFilter(conditions[0][__ctx], "OR", ...conditions);
+}


### PR DESCRIPTION
## Summary
- Add standalone `and()` and `or()` combiner functions for composing compound `WHERE` conditions with explicit precedence
- Fix parenthesization in `joiningFilter` so nested compounds produce correctly grouped SurrealQL (e.g., `(a AND (b OR c))`)