### PR TITLE
Add type-safe support for user-defined functions and API endpoints

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./error";
 export * from "./functions/standalone";
+export * from "./query/api";
 export * from "./query/batch";
 export * from "./query/create";
 export * from "./query/delete";

--- a/src/query/api.ts
+++ b/src/query/api.ts
@@ -1,0 +1,213 @@
+import type { SurrealSession } from "surrealdb";
+import type {
+	ApiEndpointSchema,
+	ApiMethodDef,
+	ApiMethods,
+	HttpMethod,
+} from "../schema/api";
+import type { AbstractType } from "../types";
+
+// ---------------------------------------------------------------------------
+// Type-level helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds a type-level map from endpoint path to its method definitions.
+ * Given `[ApiEndpointSchema<"/users", M1>, ApiEndpointSchema<"/posts", M2>]`,
+ * produces `{ "/users": M1; "/posts": M2 }`.
+ */
+type EndpointsMap<E extends ApiEndpointSchema[]> = {
+	[K in E[number] as K["path"]]: K["methods"];
+};
+
+/**
+ * Extracts the set of endpoint paths that support a given HTTP method.
+ */
+type PathsForMethod<Map, M extends HttpMethod> = {
+	[P in keyof Map]: M extends keyof Map[P] ? P : never;
+}[keyof Map] &
+	string;
+
+/**
+ * Extracts the inferred response type for a given path and method.
+ */
+type ResponseType<
+	Map,
+	P extends string,
+	M extends HttpMethod,
+> = P extends keyof Map
+	? M extends keyof Map[P]
+		? Map[P][M] extends { response: AbstractType }
+			? Map[P][M]["response"]["infer"]
+			: unknown
+		: unknown
+	: unknown;
+
+/**
+ * Extracts the inferred request body type for a given path and method.
+ */
+type RequestType<
+	Map,
+	P extends string,
+	M extends HttpMethod,
+> = P extends keyof Map
+	? M extends keyof Map[P]
+		? Map[P][M] extends { request: AbstractType }
+			? Map[P][M]["request"]["infer"]
+			: undefined
+		: undefined
+	: undefined;
+
+/**
+ * The response shape returned by API endpoints.
+ */
+export interface ApiResponse<T> {
+	body?: T;
+	headers?: Record<string, string>;
+	status?: number;
+}
+
+// ---------------------------------------------------------------------------
+// ApiClient
+// ---------------------------------------------------------------------------
+
+/**
+ * A type-safe wrapper around the SurrealDB SDK's `SurrealApi` that validates
+ * responses against Surqlize endpoint schemas.
+ *
+ * Created via `db.api()` on an {@link Orm} instance.
+ *
+ * @typeParam E - Tuple of {@link ApiEndpointSchema} types.
+ */
+export class ApiClient<E extends ApiEndpointSchema[] = ApiEndpointSchema[]> {
+	private schemas: Map<string, ApiMethods>;
+
+	constructor(
+		private readonly surreal: SurrealSession,
+		endpoints: E,
+	) {
+		this.schemas = new Map();
+		for (const ep of endpoints) {
+			this.schemas.set(ep.path, ep.methods);
+		}
+	}
+
+	// -------------------------------------------------------------------
+	// Internal helpers
+	// -------------------------------------------------------------------
+
+	private getMethodDef(
+		path: string,
+		method: HttpMethod,
+	): ApiMethodDef | undefined {
+		return this.schemas.get(path)?.[method];
+	}
+
+	private parseBody(body: unknown, path: string, method: HttpMethod): unknown {
+		const def = this.getMethodDef(path, method);
+		if (def?.response && body !== undefined) {
+			return def.response.parse(body);
+		}
+		return body;
+	}
+
+	private async invoke<T>(
+		path: string,
+		method: HttpMethod,
+		body?: unknown,
+	): Promise<ApiResponse<T>> {
+		const sdkApi = this.surreal.api();
+		const response = (await sdkApi.invoke(path, {
+			method,
+			body,
+		})) as ApiResponse<unknown>;
+		response.body = this.parseBody(response.body, path, method);
+		return response as ApiResponse<T>;
+	}
+
+	// -------------------------------------------------------------------
+	// Public API
+	// -------------------------------------------------------------------
+
+	/**
+	 * Invoke a user-defined GET API endpoint.
+	 *
+	 * @param path - The endpoint path.
+	 * @returns The typed API response.
+	 */
+	get<P extends PathsForMethod<EndpointsMap<E>, "get">>(
+		path: P,
+	): Promise<ApiResponse<ResponseType<EndpointsMap<E>, P, "get">>> {
+		return this.invoke(path, "get");
+	}
+
+	/**
+	 * Invoke a user-defined POST API endpoint.
+	 *
+	 * @param path - The endpoint path.
+	 * @param body - The request body.
+	 * @returns The typed API response.
+	 */
+	post<P extends PathsForMethod<EndpointsMap<E>, "post">>(
+		path: P,
+		body?: RequestType<EndpointsMap<E>, P, "post">,
+	): Promise<ApiResponse<ResponseType<EndpointsMap<E>, P, "post">>> {
+		return this.invoke(path, "post", body);
+	}
+
+	/**
+	 * Invoke a user-defined PUT API endpoint.
+	 *
+	 * @param path - The endpoint path.
+	 * @param body - The request body.
+	 * @returns The typed API response.
+	 */
+	put<P extends PathsForMethod<EndpointsMap<E>, "put">>(
+		path: P,
+		body?: RequestType<EndpointsMap<E>, P, "put">,
+	): Promise<ApiResponse<ResponseType<EndpointsMap<E>, P, "put">>> {
+		return this.invoke(path, "put", body);
+	}
+
+	/**
+	 * Invoke a user-defined DELETE API endpoint.
+	 *
+	 * @param path - The endpoint path.
+	 * @param body - Optional request body.
+	 * @returns The typed API response.
+	 */
+	delete<P extends PathsForMethod<EndpointsMap<E>, "delete">>(
+		path: P,
+		body?: RequestType<EndpointsMap<E>, P, "delete">,
+	): Promise<ApiResponse<ResponseType<EndpointsMap<E>, P, "delete">>> {
+		return this.invoke(path, "delete", body);
+	}
+
+	/**
+	 * Invoke a user-defined PATCH API endpoint.
+	 *
+	 * @param path - The endpoint path.
+	 * @param body - The request body.
+	 * @returns The typed API response.
+	 */
+	patch<P extends PathsForMethod<EndpointsMap<E>, "patch">>(
+		path: P,
+		body?: RequestType<EndpointsMap<E>, P, "patch">,
+	): Promise<ApiResponse<ResponseType<EndpointsMap<E>, P, "patch">>> {
+		return this.invoke(path, "patch", body);
+	}
+
+	/**
+	 * Invoke a user-defined TRACE API endpoint.
+	 *
+	 * @param path - The endpoint path.
+	 * @param body - Optional request body.
+	 * @returns The typed API response.
+	 */
+	trace<P extends PathsForMethod<EndpointsMap<E>, "trace">>(
+		path: P,
+		body?: RequestType<EndpointsMap<E>, P, "trace">,
+	): Promise<ApiResponse<ResponseType<EndpointsMap<E>, P, "trace">>> {
+		return this.invoke(path, "trace", body);
+	}
+}

--- a/src/schema/api.ts
+++ b/src/schema/api.ts
@@ -1,0 +1,67 @@
+import type { AbstractType } from "../types";
+
+/** Supported HTTP methods for API endpoints. */
+export type HttpMethod = "get" | "post" | "put" | "delete" | "patch" | "trace";
+
+/**
+ * Defines the request and response types for a single HTTP method
+ * on an API endpoint.
+ */
+export interface ApiMethodDef {
+	/** The type of the request body (omit for methods with no body, e.g. GET). */
+	request?: AbstractType;
+	/** The type of the response body. */
+	response?: AbstractType;
+}
+
+/**
+ * Maps HTTP methods to their request/response type definitions for
+ * an API endpoint.
+ */
+export type ApiMethods = Partial<Record<HttpMethod, ApiMethodDef>>;
+
+/**
+ * Schema definition for a custom SurrealDB API endpoint (`DEFINE API`).
+ * Stores the endpoint path and HTTP method definitions with typed
+ * request/response bodies.
+ *
+ * Use the {@link api} factory function to create instances rather than
+ * constructing this class directly.
+ *
+ * @typeParam Path - The endpoint path literal type.
+ * @typeParam Methods - The HTTP method definitions.
+ */
+export class ApiEndpointSchema<
+	Path extends string = string,
+	Methods extends ApiMethods = ApiMethods,
+> {
+	constructor(
+		public readonly path: Path,
+		public readonly methods: Methods,
+	) {}
+}
+
+/**
+ * Define a custom SurrealDB API endpoint schema.
+ *
+ * @param path - The endpoint path (e.g. `"/users"`).
+ * @param methods - An object mapping HTTP methods to their request/response type definitions.
+ * @returns An {@link ApiEndpointSchema} instance.
+ *
+ * @example
+ * ```ts
+ * const usersEndpoint = api("/users", {
+ *   get: { response: t.array(user.schema) },
+ *   post: {
+ *     request: t.object({ name: t.string(), email: t.string() }),
+ *     response: user.schema,
+ *   },
+ * });
+ * ```
+ */
+export function api<Path extends string, Methods extends ApiMethods>(
+	path: Path,
+	methods: Methods,
+): ApiEndpointSchema<Path, Methods> {
+	return new ApiEndpointSchema(path, methods);
+}

--- a/src/schema/function.ts
+++ b/src/schema/function.ts
@@ -1,0 +1,113 @@
+import type { ContextSource } from "../functions/standalone";
+import { standaloneFn } from "../functions/standalone";
+import type { AbstractType } from "../types";
+import type { Workable, WorkableContext } from "../utils";
+import type { Actionable } from "../utils/actionable";
+
+/**
+ * Infers the TypeScript types from a tuple of `AbstractType` parameters.
+ *
+ * @example
+ * ```ts
+ * type P = InferParams<[StringType, NumberType]>;
+ * // => [string, number]
+ * ```
+ */
+export type InferParams<P extends AbstractType[]> = {
+	[K in keyof P]: P[K]["infer"];
+};
+
+/**
+ * Maps a tuple of `AbstractType` parameters to a tuple of `Workable` values,
+ * used when calling a function within a query context.
+ */
+type WorkableParams<C extends WorkableContext, P extends AbstractType[]> = {
+	[K in keyof P]: Workable<C, P[K]>;
+};
+
+/**
+ * The shape of a callable user-defined function returned by {@link fn}.
+ * Can be called in two ways:
+ *
+ * 1. **In queries** – pass a `ContextSource` and `Workable` arguments to produce
+ *    an `Actionable` that renders as `fn::name(arg1, arg2)` in SurrealQL.
+ * 2. **Standalone via `db.run()`** – pass the callable to `db.run()` with raw
+ *    values to execute the function on the server.
+ *
+ * The `.schema` property provides access to the underlying {@link FunctionSchema}.
+ */
+export type FunctionCallable<
+	P extends AbstractType[] = AbstractType[],
+	R extends AbstractType = AbstractType,
+> = (<C extends WorkableContext>(
+	source: ContextSource<C>,
+	...args: WorkableParams<C, P>
+) => Actionable<C, R>) & {
+	schema: FunctionSchema<P, R>;
+};
+
+/**
+ * Schema definition for a user-defined SurrealDB function (`DEFINE FUNCTION`).
+ * Stores the function name, parameter types, and return type.
+ *
+ * Use the {@link fn} factory function to create callable instances rather than
+ * constructing this class directly.
+ *
+ * @typeParam P - Tuple of parameter types.
+ * @typeParam R - The return type.
+ */
+export class FunctionSchema<
+	P extends AbstractType[] = AbstractType[],
+	R extends AbstractType = AbstractType,
+> {
+	constructor(
+		public readonly name: string,
+		public readonly params: P,
+		public readonly returns: R,
+	) {}
+}
+
+/**
+ * Define a user-defined SurrealDB function schema. Returns a callable that can
+ * be used both inside queries (producing `fn::name(...)` in SurrealQL) and
+ * passed to `db.run()` for standalone execution.
+ *
+ * @param name - The function name (without the `fn::` prefix).
+ * @param params - A tuple of parameter types.
+ * @param returns - The return type.
+ * @returns A {@link FunctionCallable} with an attached `.schema` property.
+ *
+ * @example
+ * ```ts
+ * const greet = fn("greet", [t.string()], t.string());
+ *
+ * // In a query
+ * db.select("user").return(u => ({ greeting: greet(u, u.name) }));
+ *
+ * // Standalone
+ * const result = await db.run(greet, ["world"]);
+ * ```
+ */
+export function fn<P extends AbstractType[], R extends AbstractType>(
+	name: string,
+	params: P,
+	returns: R,
+): FunctionCallable<P, R> {
+	const schema = new FunctionSchema(name, params, returns);
+
+	const callable = <C extends WorkableContext>(
+		source: ContextSource<C>,
+		...args: WorkableParams<C, P>
+	): Actionable<C, R> => {
+		return standaloneFn(
+			source,
+			returns,
+			`fn::${name}`,
+			...(args as Workable<C>[]),
+		);
+	};
+
+	callable.schema = schema;
+
+	return callable as FunctionCallable<P, R>;
+}

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -1,3 +1,5 @@
+export * from "./api";
 export * from "./edge";
+export * from "./function";
 export * from "./orm";
 export * from "./table";

--- a/tests/integration/api.test.ts
+++ b/tests/integration/api.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, test } from "bun:test";
+import { api, TypeParseError, t } from "../../src";
+import { withTestDb } from "./setup";
+
+/**
+ * These tests require SurrealDB v3.0.0+ started with experimental API support:
+ *   SURREAL_CAPS_ALLOW_EXPERIMENTAL=define_api surreal start ...
+ *
+ * Tests will skip gracefully if DEFINE API is not available.
+ */
+describe("DEFINE API integration tests", () => {
+	const getTestDb = withTestDb({ perTest: true });
+
+	/**
+	 * Helper: attempt to define an API endpoint on the server.
+	 * Returns false if the feature is not available.
+	 */
+	async function defineApiAvailable(
+		surreal: ReturnType<typeof getTestDb>["surreal"],
+	): Promise<boolean> {
+		try {
+			await surreal.query(`
+				DEFINE API "/health_check" FOR get THEN {
+					{ status: 200, body: "ok" };
+				};
+			`);
+			return true;
+		} catch {
+			return false;
+		}
+	}
+
+	test("GET endpoint returns typed response", async () => {
+		const { db, surreal } = getTestDb();
+
+		if (!(await defineApiAvailable(surreal))) {
+			console.log("  ⏭ Skipping: DEFINE API not available");
+			return;
+		}
+
+		await surreal.query(`
+			DEFINE API "/greeting" FOR get THEN {
+				{
+					status: 200,
+					body: { message: "Hello from API" }
+				};
+			};
+		`);
+
+		const greetingEndpoint = api("/greeting", {
+			get: {
+				response: t.object({ message: t.string() }),
+			},
+		});
+
+		const client = db.api(greetingEndpoint);
+		const response = await client.get("/greeting");
+
+		expect(response.status).toBe(200);
+		expect(response.body).toBeDefined();
+		expect(response.body!.message).toBe("Hello from API");
+	});
+
+	test("POST endpoint with request body", async () => {
+		const { db, surreal } = getTestDb();
+
+		if (!(await defineApiAvailable(surreal))) {
+			console.log("  ⏭ Skipping: DEFINE API not available");
+			return;
+		}
+
+		await surreal.query(`
+			DEFINE API "/echo" FOR post THEN {
+				{
+					status: 200,
+					body: $request.body
+				};
+			};
+		`);
+
+		const echoEndpoint = api("/echo", {
+			post: {
+				request: t.object({ text: t.string() }),
+				response: t.object({ text: t.string() }),
+			},
+		});
+
+		const client = db.api(echoEndpoint);
+		const response = await client.post("/echo", { text: "hello" });
+
+		expect(response.status).toBe(200);
+		expect(response.body).toBeDefined();
+		expect(response.body!.text).toBe("hello");
+	});
+
+	test("multiple endpoints on one client", async () => {
+		const { db, surreal } = getTestDb();
+
+		if (!(await defineApiAvailable(surreal))) {
+			console.log("  ⏭ Skipping: DEFINE API not available");
+			return;
+		}
+
+		await surreal.query(`
+			DEFINE API "/status" FOR get THEN {
+				{ status: 200, body: { ok: true } };
+			};
+			DEFINE API "/version" FOR get THEN {
+				{ status: 200, body: { version: "1.0.0" } };
+			};
+		`);
+
+		const statusEndpoint = api("/status", {
+			get: { response: t.object({ ok: t.bool() }) },
+		});
+		const versionEndpoint = api("/version", {
+			get: { response: t.object({ version: t.string() }) },
+		});
+
+		const client = db.api(statusEndpoint, versionEndpoint);
+
+		const status = await client.get("/status");
+		expect(status.body!.ok).toBe(true);
+
+		const version = await client.get("/version");
+		expect(version.body!.version).toBe("1.0.0");
+	});
+
+	test("PUT endpoint with request body", async () => {
+		const { db, surreal } = getTestDb();
+
+		if (!(await defineApiAvailable(surreal))) {
+			console.log("  ⏭ Skipping: DEFINE API not available");
+			return;
+		}
+
+		await surreal.query(`
+			DEFINE API "/item" FOR put THEN {
+				{
+					status: 200,
+					body: { replaced: true, data: $request.body }
+				};
+			};
+		`);
+
+		const itemEndpoint = api("/item", {
+			put: {
+				request: t.object({ name: t.string() }),
+				response: t.object({
+					replaced: t.bool(),
+					data: t.object({ name: t.string() }),
+				}),
+			},
+		});
+
+		const client = db.api(itemEndpoint);
+		const response = await client.put("/item", { name: "updated" });
+
+		expect(response.status).toBe(200);
+		expect(response.body!.replaced).toBe(true);
+		expect(response.body!.data.name).toBe("updated");
+	});
+
+	test("DELETE endpoint", async () => {
+		const { db, surreal } = getTestDb();
+
+		if (!(await defineApiAvailable(surreal))) {
+			console.log("  ⏭ Skipping: DEFINE API not available");
+			return;
+		}
+
+		await surreal.query(`
+			DEFINE API "/item" FOR delete THEN {
+				{
+					status: 200,
+					body: { deleted: true }
+				};
+			};
+		`);
+
+		const itemEndpoint = api("/item", {
+			delete: {
+				response: t.object({ deleted: t.bool() }),
+			},
+		});
+
+		const client = db.api(itemEndpoint);
+		const response = await client.delete("/item");
+
+		expect(response.status).toBe(200);
+		expect(response.body!.deleted).toBe(true);
+	});
+
+	test("PATCH endpoint with request body", async () => {
+		const { db, surreal } = getTestDb();
+
+		if (!(await defineApiAvailable(surreal))) {
+			console.log("  ⏭ Skipping: DEFINE API not available");
+			return;
+		}
+
+		await surreal.query(`
+			DEFINE API "/item" FOR patch THEN {
+				{
+					status: 200,
+					body: { patched: true, field: $request.body.field }
+				};
+			};
+		`);
+
+		const itemEndpoint = api("/item", {
+			patch: {
+				request: t.object({ field: t.string() }),
+				response: t.object({ patched: t.bool(), field: t.string() }),
+			},
+		});
+
+		const client = db.api(itemEndpoint);
+		const response = await client.patch("/item", { field: "value" });
+
+		expect(response.status).toBe(200);
+		expect(response.body!.patched).toBe(true);
+		expect(response.body!.field).toBe("value");
+	});
+
+	test("throws TypeParseError when response body does not match schema", async () => {
+		const { db, surreal } = getTestDb();
+
+		if (!(await defineApiAvailable(surreal))) {
+			console.log("  ⏭ Skipping: DEFINE API not available");
+			return;
+		}
+
+		// Endpoint returns a string, but schema expects a number
+		await surreal.query(`
+			DEFINE API "/wrong_type" FOR get THEN {
+				{
+					status: 200,
+					body: "i am a string"
+				};
+			};
+		`);
+
+		const endpoint = api("/wrong_type", {
+			get: { response: t.number() },
+		});
+
+		const client = db.api(endpoint);
+
+		try {
+			await client.get("/wrong_type");
+			// Should not reach here
+			expect(true).toBe(false);
+		} catch (err) {
+			expect(err).toBeInstanceOf(TypeParseError);
+		}
+	});
+});

--- a/tests/integration/functions.test.ts
+++ b/tests/integration/functions.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, test } from "bun:test";
+import { fn, TypeParseError, t } from "../../src";
+import { withTestDb } from "./setup";
+
+describe("User-defined function integration tests", () => {
+	const getTestDb = withTestDb({ perTest: true });
+
+	describe("db.run()", () => {
+		test("runs a function with a single argument", async () => {
+			const { db, surreal } = getTestDb();
+
+			// Define the function in SurrealDB
+			await surreal.query(`
+				DEFINE FUNCTION fn::greet($name: string) {
+					RETURN "Hello, " + $name;
+				};
+			`);
+
+			const greet = fn("greet", [t.string()], t.string());
+			const result = await db.run(greet, ["world"]);
+
+			expect(result).toBe("Hello, world");
+		});
+
+		test("runs a function with multiple arguments", async () => {
+			const { db, surreal } = getTestDb();
+
+			await surreal.query(`
+				DEFINE FUNCTION fn::add($a: number, $b: number) {
+					RETURN $a + $b;
+				};
+			`);
+
+			const add = fn("add", [t.number(), t.number()], t.number());
+			const result = await db.run(add, [3, 7]);
+
+			expect(result).toBe(10);
+		});
+
+		test("runs a function with no arguments", async () => {
+			const { db, surreal } = getTestDb();
+
+			await surreal.query(`
+				DEFINE FUNCTION fn::get_pi() {
+					RETURN 3.14;
+				};
+			`);
+
+			const getPi = fn("get_pi", [], t.number());
+			const result = await db.run(getPi);
+
+			expect(result).toBe(3.14);
+		});
+
+		test("runs a function that returns an object", async () => {
+			const { db, surreal } = getTestDb();
+
+			await surreal.query(`
+				DEFINE FUNCTION fn::make_pair($key: string, $val: string) {
+					RETURN { key: $key, val: $val };
+				};
+			`);
+
+			const makePair = fn(
+				"make_pair",
+				[t.string(), t.string()],
+				t.object({ key: t.string(), val: t.string() }),
+			);
+
+			const result = await db.run(makePair, ["name", "Alice"]);
+
+			expect(result.key).toBe("name");
+			expect(result.val).toBe("Alice");
+		});
+	});
+
+	describe("fn() in queries", () => {
+		test("uses a function in a return projection", async () => {
+			const { db, surreal } = getTestDb();
+
+			await surreal.query(`
+				DEFINE FUNCTION fn::shout($text: string) {
+					RETURN string::uppercase($text);
+				};
+
+				CREATE user:alice SET
+					name = { first: "Alice", last: "Smith" },
+					age = 30,
+					email = "alice@example.com",
+					created = time::now(),
+					updated = time::now();
+			`);
+
+			const shout = fn("shout", [t.string()], t.string());
+
+			const result = await db
+				.select("user")
+				.return((u) => ({
+					loud_email: shout(u, u.email),
+				}))
+				.execute();
+
+			expect(result).toHaveLength(1);
+			expect(result[0]!.loud_email).toBe("ALICE@EXAMPLE.COM");
+		});
+
+		test("uses a function in a WHERE clause to filter results", async () => {
+			const { db, surreal } = getTestDb();
+
+			await surreal.query(`
+				DEFINE FUNCTION fn::is_adult($age: number) {
+					RETURN $age >= 18;
+				};
+
+				CREATE user:alice SET
+					name = { first: "Alice", last: "Smith" },
+					age = 30,
+					email = "alice@example.com",
+					created = time::now(),
+					updated = time::now();
+
+				CREATE user:bob SET
+					name = { first: "Bob", last: "Jones" },
+					age = 12,
+					email = "bob@example.com",
+					created = time::now(),
+					updated = time::now();
+
+				CREATE user:charlie SET
+					name = { first: "Charlie", last: "Brown" },
+					age = 25,
+					email = "charlie@example.com",
+					created = time::now(),
+					updated = time::now();
+			`);
+
+			const isAdult = fn("is_adult", [t.number()], t.bool());
+
+			const result = await db
+				.select("user")
+				.where((u) => isAdult(u, u.age))
+				.execute();
+
+			expect(result).toHaveLength(2);
+			const names = result.map((r) => r.name.first).sort();
+			expect(names).toEqual(["Alice", "Charlie"]);
+		});
+	});
+
+	describe("db.run() in transactions", () => {
+		test("runs a function inside a transaction", async () => {
+			const { db, surreal } = getTestDb();
+
+			await surreal.query(`
+				DEFINE FUNCTION fn::greet($name: string) {
+					RETURN "Hello, " + $name;
+				};
+			`);
+
+			const greet = fn("greet", [t.string()], t.string());
+
+			const result = await db.transaction(async (tx) => {
+				return tx.run(greet, ["world"]);
+			});
+
+			expect(result).toBe("Hello, world");
+		});
+	});
+
+	describe("db.run() error handling", () => {
+		test("throws TypeParseError when return type does not match schema", async () => {
+			const { db, surreal } = getTestDb();
+
+			// Function returns a string, but we declare the schema as t.number()
+			await surreal.query(`
+				DEFINE FUNCTION fn::returns_string() {
+					RETURN "i am a string";
+				};
+			`);
+
+			const wrongType = fn("returns_string", [], t.number());
+
+			try {
+				await db.run(wrongType);
+				// Should not reach here
+				expect(true).toBe(false);
+			} catch (err) {
+				expect(err).toBeInstanceOf(TypeParseError);
+			}
+		});
+	});
+});

--- a/tests/unit/query/api.test.ts
+++ b/tests/unit/query/api.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, test } from "bun:test";
+import type { SurrealSession } from "surrealdb";
+import { ApiClient, api, TypeParseError, t } from "../../../src";
+
+/**
+ * Creates a mock SurrealSession whose `.api().invoke()` returns
+ * the given response. This lets us test ApiClient's parsing and
+ * delegation logic without a real database.
+ */
+function mockSurreal(invokeResult: unknown): SurrealSession {
+	return {
+		api() {
+			return {
+				invoke: () => Promise.resolve(invokeResult),
+			};
+		},
+	} as unknown as SurrealSession;
+}
+
+describe("ApiClient", () => {
+	describe("response parsing", () => {
+		test("get() parses response body through the schema", async () => {
+			const surreal = mockSurreal({
+				status: 200,
+				body: "hello",
+			});
+
+			const endpoint = api("/test", {
+				get: { response: t.string() },
+			});
+
+			const client = new ApiClient(surreal, [endpoint]);
+			const response = await client.get("/test");
+
+			expect(response.status).toBe(200);
+			expect(response.body).toBe("hello");
+		});
+
+		test("post() passes body and parses response", async () => {
+			const surreal = mockSurreal({
+				status: 201,
+				body: { id: "123", name: "Alice" },
+			});
+
+			const endpoint = api("/users", {
+				post: {
+					request: t.object({ name: t.string() }),
+					response: t.object({ id: t.string(), name: t.string() }),
+				},
+			});
+
+			const client = new ApiClient(surreal, [endpoint]);
+			const response = await client.post("/users", { name: "Alice" });
+
+			expect(response.status).toBe(201);
+			expect(response.body).toEqual({ id: "123", name: "Alice" });
+		});
+
+		test("put() delegates correctly", async () => {
+			const surreal = mockSurreal({
+				status: 200,
+				body: { updated: true },
+			});
+
+			const endpoint = api("/item", {
+				put: {
+					request: t.object({ value: t.number() }),
+					response: t.object({ updated: t.bool() }),
+				},
+			});
+
+			const client = new ApiClient(surreal, [endpoint]);
+			const response = await client.put("/item", { value: 42 });
+
+			expect(response.status).toBe(200);
+			expect(response.body).toEqual({ updated: true });
+		});
+
+		test("delete() delegates correctly", async () => {
+			const surreal = mockSurreal({
+				status: 200,
+				body: { deleted: true },
+			});
+
+			const endpoint = api("/item", {
+				delete: { response: t.object({ deleted: t.bool() }) },
+			});
+
+			const client = new ApiClient(surreal, [endpoint]);
+			const response = await client.delete("/item");
+
+			expect(response.status).toBe(200);
+			expect(response.body).toEqual({ deleted: true });
+		});
+
+		test("patch() delegates correctly", async () => {
+			const surreal = mockSurreal({
+				status: 200,
+				body: { patched: true },
+			});
+
+			const endpoint = api("/item", {
+				patch: {
+					request: t.object({ field: t.string() }),
+					response: t.object({ patched: t.bool() }),
+				},
+			});
+
+			const client = new ApiClient(surreal, [endpoint]);
+			const response = await client.patch("/item", { field: "value" });
+
+			expect(response.status).toBe(200);
+			expect(response.body).toEqual({ patched: true });
+		});
+	});
+
+	describe("schema validation", () => {
+		test("throws TypeParseError when body does not match response schema", async () => {
+			const surreal = mockSurreal({
+				status: 200,
+				body: "not_a_number",
+			});
+
+			const endpoint = api("/typed", {
+				get: { response: t.number() },
+			});
+
+			const client = new ApiClient(surreal, [endpoint]);
+
+			expect(client.get("/typed")).rejects.toThrow(TypeParseError);
+		});
+
+		test("returns undefined body as-is without parsing", async () => {
+			const surreal = mockSurreal({
+				status: 204,
+				body: undefined,
+			});
+
+			const endpoint = api("/empty", {
+				get: { response: t.string() },
+			});
+
+			const client = new ApiClient(surreal, [endpoint]);
+			const response = await client.get("/empty");
+
+			expect(response.status).toBe(204);
+			expect(response.body).toBeUndefined();
+		});
+
+		test("returns body unparsed when endpoint has no response schema", async () => {
+			const surreal = mockSurreal({
+				status: 200,
+				body: { anything: "goes" },
+			});
+
+			const endpoint = api("/untyped", {
+				get: {},
+			});
+
+			const client = new ApiClient(surreal, [endpoint]);
+			const response = await client.get("/untyped");
+
+			expect(response.status).toBe(200);
+			expect(response.body).toEqual({ anything: "goes" });
+		});
+
+		test("validates complex nested response types", async () => {
+			const surreal = mockSurreal({
+				status: 200,
+				body: { users: ["Alice", "Bob"] },
+			});
+
+			const endpoint = api("/complex", {
+				get: {
+					response: t.object({
+						users: t.array(t.string()),
+					}),
+				},
+			});
+
+			const client = new ApiClient(surreal, [endpoint]);
+			const response = await client.get("/complex");
+
+			expect(response.body).toEqual({ users: ["Alice", "Bob"] });
+		});
+	});
+});

--- a/tests/unit/schema/api.test.ts
+++ b/tests/unit/schema/api.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+import { ApiEndpointSchema, api, t } from "../../../src";
+
+describe("ApiEndpointSchema", () => {
+	test("creates schema with path and methods", () => {
+		const endpoint = new ApiEndpointSchema("/users", {
+			get: { response: t.array(t.string()) },
+		});
+
+		expect(endpoint.path).toBe("/users");
+		expect(endpoint.methods.get).toBeDefined();
+		expect(endpoint.methods.get!.response!.name).toBe("array");
+	});
+
+	test("creates schema with multiple methods", () => {
+		const endpoint = new ApiEndpointSchema("/users", {
+			get: { response: t.array(t.string()) },
+			post: {
+				request: t.object({ name: t.string() }),
+				response: t.object({ id: t.string(), name: t.string() }),
+			},
+			delete: {},
+		});
+
+		expect(endpoint.methods.get).toBeDefined();
+		expect(endpoint.methods.post).toBeDefined();
+		expect(endpoint.methods.delete).toBeDefined();
+		expect("put" in endpoint.methods).toBe(false);
+	});
+
+	test("handles request and response types", () => {
+		const endpoint = new ApiEndpointSchema("/data", {
+			post: {
+				request: t.object({ key: t.string(), value: t.number() }),
+				response: t.bool(),
+			},
+		});
+
+		expect(endpoint.methods.post!.request!.name).toBe("object");
+		expect(endpoint.methods.post!.response!.name).toBe("bool");
+	});
+});
+
+describe("api() factory", () => {
+	test("creates an ApiEndpointSchema", () => {
+		const endpoint = api("/users", {
+			get: { response: t.array(t.string()) },
+		});
+
+		expect(endpoint).toBeInstanceOf(ApiEndpointSchema);
+		expect(endpoint.path).toBe("/users");
+	});
+
+	test("preserves typed path", () => {
+		const endpoint = api("/users/active", {
+			get: { response: t.number() },
+		});
+
+		expect(endpoint.path).toBe("/users/active");
+	});
+
+	test("supports all HTTP methods", () => {
+		const endpoint = api("/test", {
+			get: { response: t.string() },
+			post: { request: t.string(), response: t.string() },
+			put: { request: t.string(), response: t.string() },
+			delete: { response: t.bool() },
+			patch: { request: t.string(), response: t.string() },
+			trace: { response: t.string() },
+		});
+
+		expect(endpoint.methods.get).toBeDefined();
+		expect(endpoint.methods.post).toBeDefined();
+		expect(endpoint.methods.put).toBeDefined();
+		expect(endpoint.methods.delete).toBeDefined();
+		expect(endpoint.methods.patch).toBeDefined();
+		expect(endpoint.methods.trace).toBeDefined();
+	});
+});

--- a/tests/unit/schema/function.test.ts
+++ b/tests/unit/schema/function.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, test } from "bun:test";
+import { Surreal } from "surrealdb";
+import {
+	__display,
+	displayContext,
+	FunctionSchema,
+	fn,
+	orm,
+	t,
+	table,
+} from "../../../src";
+
+describe("FunctionSchema", () => {
+	test("creates schema with name, params, and return type", () => {
+		const schema = new FunctionSchema("greet", [t.string()], t.string());
+
+		expect(schema.name).toBe("greet");
+		expect(schema.params).toHaveLength(1);
+		expect(schema.params[0]!.name).toBe("string");
+		expect(schema.returns.name).toBe("string");
+	});
+
+	test("creates schema with multiple params", () => {
+		const schema = new FunctionSchema(
+			"add",
+			[t.number(), t.number()],
+			t.number(),
+		);
+
+		expect(schema.name).toBe("add");
+		expect(schema.params).toHaveLength(2);
+		expect(schema.params[0]!.name).toBe("number");
+		expect(schema.params[1]!.name).toBe("number");
+		expect(schema.returns.name).toBe("number");
+	});
+
+	test("creates schema with no params", () => {
+		const schema = new FunctionSchema("now", [], t.date());
+
+		expect(schema.name).toBe("now");
+		expect(schema.params).toHaveLength(0);
+		expect(schema.returns.name).toBe("date");
+	});
+});
+
+describe("fn() factory", () => {
+	const user = table("user", {
+		name: t.string(),
+		age: t.number(),
+		email: t.string(),
+	});
+
+	const db = orm(new Surreal(), user);
+
+	test("returns a callable with .schema property", () => {
+		const greet = fn("greet", [t.string()], t.string());
+
+		expect(typeof greet).toBe("function");
+		expect(greet.schema).toBeInstanceOf(FunctionSchema);
+		expect(greet.schema.name).toBe("greet");
+	});
+
+	test("generates fn::name() SurrealQL in return projection", () => {
+		const greet = fn("greet", [t.string()], t.string());
+
+		const query = db.select("user").return((u) => ({
+			greeting: greet(u, u.name),
+		}));
+		const ctx = displayContext();
+		const result = query[__display](ctx);
+
+		expect(result).toContain("fn::greet(");
+	});
+
+	test("generates fn::name() SurrealQL in where clause", () => {
+		const isActive = fn("is_active", [t.number()], t.bool());
+
+		const query = db.select("user").where((u) => isActive(u, u.age));
+		const ctx = displayContext();
+		const result = query[__display](ctx);
+
+		expect(result).toContain("WHERE");
+		expect(result).toContain("fn::is_active(");
+	});
+
+	test("generates fn::name() with no arguments", () => {
+		const getDefault = fn("get_default", [], t.string());
+
+		const query = db.select("user").return((u) => ({
+			default: getDefault(u),
+		}));
+		const ctx = displayContext();
+		const result = query[__display](ctx);
+
+		expect(result).toContain("fn::get_default()");
+	});
+
+	test("generates fn::name() with multiple arguments", () => {
+		const combine = fn("combine", [t.string(), t.string()], t.string());
+
+		const query = db.select("user").return((u) => ({
+			full: combine(u, u.name, u.email),
+		}));
+		const ctx = displayContext();
+		const result = query[__display](ctx);
+
+		expect(result).toContain("fn::combine(");
+	});
+
+	test("preserves namespaced function names", () => {
+		const myFn = fn("utils::format", [t.string()], t.string());
+
+		const query = db.select("user").return((u) => ({
+			formatted: myFn(u, u.name),
+		}));
+		const ctx = displayContext();
+		const result = query[__display](ctx);
+
+		expect(result).toContain("fn::utils::format(");
+	});
+
+	test("generates fn::name() in UPDATE return projection", () => {
+		const formatAge = fn("format_age", [t.number()], t.string());
+
+		const query = db
+			.update("user", "alice")
+			.set({ age: 32 })
+			.return((u) => ({
+				formatted: formatAge(u, u.age),
+			}));
+		const ctx = displayContext();
+		const result = query[__display](ctx);
+
+		expect(result).toContain("UPDATE");
+		expect(result).toContain("fn::format_age(");
+	});
+
+	test("generates fn::name() in CREATE return projection", () => {
+		const greet = fn("greet", [t.string()], t.string());
+
+		const query = db
+			.create("user")
+			.set({ name: "Alice", age: 30, email: "alice@example.com" })
+			.return((u) => ({
+				greeting: greet(u, u.name),
+			}));
+		const ctx = displayContext();
+		const result = query[__display](ctx);
+
+		expect(result).toContain("CREATE");
+		expect(result).toContain("fn::greet(");
+	});
+
+	test("generates nested fn() calls", () => {
+		const inner = fn("inner", [t.string()], t.string());
+		const outer = fn("outer", [t.string()], t.string());
+
+		const query = db.select("user").return((u) => ({
+			result: outer(u, inner(u, u.name)),
+		}));
+		const ctx = displayContext();
+		const result = query[__display](ctx);
+
+		expect(result).toContain("fn::outer(fn::inner(");
+	});
+
+	test("fn() with complex return type carries correct __type", () => {
+		const getProfile = fn(
+			"get_profile",
+			[t.string()],
+			t.object({ name: t.string(), score: t.number() }),
+		);
+
+		expect(getProfile.schema.returns.name).toBe("object");
+		expect(getProfile.schema.returns.schema).toHaveProperty("name");
+		expect(getProfile.schema.returns.schema).toHaveProperty("score");
+		expect(getProfile.schema.returns.schema.name.name).toBe("string");
+		expect(getProfile.schema.returns.schema.score.name).toBe("number");
+	});
+});


### PR DESCRIPTION
Adds two new features to Surqlize:
- `fn()` for defining user-defined SurrealDB functions (`DEFINE FUNCTION`) that can be called both inside queries (WHERE, RETURN) and standalone via `db.run()`
- `api()` for defining custom API endpoints (`DEFINE API`) with a type-safe `ApiClient` wrapping the SDK's `SurrealApi`, accessible via `db.api()`.

Both features integrate with the existing `t.*` type system for full TypeScript inference and runtime validation.