### PR TITLE
Fix zero-value pagination, composite CREATE ids, and batched RETURN DIFF parsing

### DIFF
--- a/src/query/abstract.ts
+++ b/src/query/abstract.ts
@@ -29,7 +29,7 @@ export abstract class Query<
 	abstract [__type]: T;
 
 	type = undefined as unknown as T["infer"];
-	/** When true, execute() skips schema parsing (used by RETURN DIFF and FETCH). */
+	/** When true, result parsing is skipped (used by RETURN DIFF). */
 	protected _skipParse = false;
 	/** Type-guard that checks whether a value matches this query's result type. */
 	validate(value: unknown): value is T["infer"] {
@@ -39,6 +39,16 @@ export abstract class Query<
 	/** Parse and validate a raw query result against this query's result type. */
 	parse(value: unknown): T["infer"] {
 		return this[__type].parse(value);
+	}
+
+	/**
+	 * Normalize a raw query result into the public return value for this query.
+	 * Most queries parse through the runtime schema, while a few modes such as
+	 * `RETURN DIFF` intentionally bypass parse.
+	 */
+	parseResult(value: unknown): T["infer"] {
+		if (this._skipParse) return value as T["infer"];
+		return this.parse(value);
 	}
 
 	/** Create a shallow clone of this query. */
@@ -107,9 +117,7 @@ export abstract class Query<
 			query,
 			ctx.variables,
 		);
-		// Skip parse for RETURN DIFF (JsonPatchOp[]) and FETCH (resolved records)
-		if (this._skipParse) return result as this["type"];
-		return this.parse(result);
+		return this.parseResult(result);
 	}
 }
 

--- a/src/query/batch.ts
+++ b/src/query/batch.ts
@@ -47,7 +47,7 @@ export class BatchQuery<Q extends Query<any, any>[]> {
 		// Skip BEGIN (first) and COMMIT (last) results
 		const queryResults = results.slice(1, results.length - 1);
 		return queryResults.map((result, i) => {
-			return this.queries[i]!.parse(result);
+			return this.queries[i]!.parseResult(result);
 		}) as BatchResult<Q>;
 	}
 

--- a/src/query/create.ts
+++ b/src/query/create.ts
@@ -1,4 +1,4 @@
-import { RecordId, Table } from "surrealdb";
+import { RecordId, Table, type RecordIdValue } from "surrealdb";
 import type { Orm } from "../schema/orm.ts";
 import {
 	type AbstractType,
@@ -57,12 +57,12 @@ export class CreateQuery<
 	_modificationMode?: ModificationMode;
 	private _return?: "none" | "before" | "after" | "diff" | Workable<C>;
 	private _timeout?: string;
-	private _id?: string;
+	private _id?: RecordIdValue;
 
 	constructor(
 		orm: O,
 		readonly tb: T,
-		id?: string,
+		id?: RecordIdValue,
 	) {
 		super();
 		this[__ctx] = {

--- a/src/query/create.ts
+++ b/src/query/create.ts
@@ -1,4 +1,4 @@
-import { RecordId, Table, type RecordIdValue } from "surrealdb";
+import { RecordId, type RecordIdValue, Table } from "surrealdb";
 import type { Orm } from "../schema/orm.ts";
 import {
 	type AbstractType,
@@ -153,7 +153,7 @@ export class CreateQuery<
 		});
 
 		let target: string;
-		if (this._id) {
+		if (this._id !== undefined) {
 			// Create a RecordId for the target instead of concatenating variables
 			const recordId = new RecordId(this.tb, this._id);
 			target = ctx.var(recordId);

--- a/src/query/select.ts
+++ b/src/query/select.ts
@@ -279,8 +279,8 @@ export class SelectQuery<
 		});
 
 		const thing = this.displaySubject(ctx);
-		const start = this._start && ctx.var(this._start);
-		const limit = this._limit && ctx.var(this._limit);
+		const start = this._start !== undefined ? ctx.var(this._start) : undefined;
+		const limit = this._limit !== undefined ? ctx.var(this._limit) : undefined;
 
 		const predicates = this._entry
 			? /* surql */ `VALUE ${this._entry[__display](ctx)}`

--- a/src/schema/orm.ts
+++ b/src/schema/orm.ts
@@ -104,7 +104,7 @@ export class Orm<T extends AnyTable[] = AnyTable[]> {
 		_C extends WorkableContext<this>,
 		Tb extends keyof this["tables"] & string,
 	>(tb: Tb, id?: RecordIdValue) {
-		return new CreateQuery(this, tb, id?.toString());
+		return new CreateQuery(this, tb, id);
 	}
 
 	/**

--- a/tests/unit/query/batch.test.ts
+++ b/tests/unit/query/batch.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from "bun:test";
-import { Surreal } from "surrealdb";
+import { Surreal, type SurrealSession } from "surrealdb";
 import { __display, displayContext, orm, t, table } from "../../../src";
+
+function mockSurrealQuery(results: unknown[]): SurrealSession {
+	return {
+		query: () => Promise.resolve(results),
+	} as unknown as SurrealSession;
+}
 
 describe("BATCH queries", () => {
 	const user = table("user", {
@@ -111,6 +117,27 @@ describe("BATCH queries", () => {
 		expect(display).toContain("BEGIN TRANSACTION;");
 		expect(str).toContain("WHERE");
 		expect(display).toContain("WHERE");
+	});
+
+	test("reuses single-query parse behavior for RETURN DIFF", async () => {
+		const surreal = mockSurrealQuery([
+			{ status: "OK" },
+			[{ op: "replace", path: "/age", value: 31 }],
+			{ status: "OK" },
+		]);
+		const batchDb = orm(surreal, user, post);
+
+		const result = (await batchDb
+			.batch(batchDb.update("user", "alice").set({ age: 31 }).return("diff"))
+			.execute()) as unknown as [
+			Array<{
+				op: string;
+				path: string;
+				value: number;
+			}>,
+		];
+
+		expect(result[0]).toEqual([{ op: "replace", path: "/age", value: 31 }]);
 	});
 
 	test("Orm has batch method", () => {

--- a/tests/unit/query/create.test.ts
+++ b/tests/unit/query/create.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { Surreal } from "surrealdb";
+import { RecordId, Surreal } from "surrealdb";
 import { __display, displayContext, orm, t, table } from "../../../src";
 
 describe("CREATE queries", () => {
@@ -38,6 +38,27 @@ describe("CREATE queries", () => {
 		expect(result).toContain("CREATE");
 		expect(result).toContain("SET");
 		// ID is in variables, not in the query string directly
+	});
+
+	test("preserves composite CREATE ids without stringifying them", () => {
+		const compositeId = {
+			tenant: "acme",
+			slug: "alice",
+		};
+		const query = db.create("user", compositeId).set({
+			name: "Alice",
+			age: 25,
+		});
+		const ctx = displayContext();
+
+		query[__display](ctx);
+
+		const recordId = Object.values(ctx.variables).find(
+			(value) => value instanceof RecordId,
+		);
+
+		expect(recordId).toBeInstanceOf(RecordId);
+		expect((recordId as RecordId).id).toEqual(compositeId);
 	});
 
 	test("generates CREATE with CONTENT", () => {

--- a/tests/unit/query/create.test.ts
+++ b/tests/unit/query/create.test.ts
@@ -40,6 +40,20 @@ describe("CREATE queries", () => {
 		// ID is in variables, not in the query string directly
 	});
 
+	test("preserves a zero-valued numeric id instead of dropping it", () => {
+		const query = db.create("user", 0).set({ name: "Zero", age: 0 });
+		const ctx = displayContext();
+
+		query[__display](ctx);
+
+		const recordId = Object.values(ctx.variables).find(
+			(value) => value instanceof RecordId,
+		);
+
+		expect(recordId).toBeInstanceOf(RecordId);
+		expect((recordId as RecordId).id).toBe(0);
+	});
+
 	test("preserves composite CREATE ids without stringifying them", () => {
 		const compositeId = {
 			tenant: "acme",

--- a/tests/unit/query/select.test.ts
+++ b/tests/unit/query/select.test.ts
@@ -57,6 +57,16 @@ describe("SELECT queries", () => {
 		expect(result).toContain("LIMIT");
 	});
 
+	test("generates SELECT with LIMIT 0", () => {
+		const query = db.select("user").limit(0);
+		const ctx = displayContext();
+		const result = query[__display](ctx);
+
+		expect(result).toContain("SELECT * FROM");
+		expect(result).toContain("LIMIT");
+		expect(Object.values(ctx.variables)).toContainEqual(0);
+	});
+
 	test("generates SELECT with START", () => {
 		const query = db.select("user").start(5);
 		const ctx = displayContext();
@@ -64,6 +74,16 @@ describe("SELECT queries", () => {
 
 		expect(result).toContain("SELECT * FROM");
 		expect(result).toContain("START");
+	});
+
+	test("generates SELECT with START 0", () => {
+		const query = db.select("user").start(0);
+		const ctx = displayContext();
+		const result = query[__display](ctx);
+
+		expect(result).toContain("SELECT * FROM");
+		expect(result).toContain("START");
+		expect(Object.values(ctx.variables)).toContainEqual(0);
 	});
 
 	test("generates SELECT with START and LIMIT", () => {


### PR DESCRIPTION
This PR fixes three query-builder edge cases and adds focused unit coverage in the existing query test files.

Changes:
- preserve `LIMIT 0` and `START 0` instead of dropping them due to truthy checks
- preserve composite `RecordIdValue` inputs in `create(tb, id)` instead of stringifying them
- make `BatchQuery.execute()` reuse the same result handling as single-query execution for `RETURN DIFF`

Tests were added to:
- `tests/unit/query/select.test.ts`
- `tests/unit/query/create.test.ts`
- `tests/unit/query/batch.test.ts`