### PR TITLE
Fix packaged t.infer declarations and add post-pack TypeScript smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,10 +171,14 @@ jobs:
           cp surqlize-*.tgz /tmp/smoke-test/
           cd /tmp/smoke-test
           npm init -y
-          npm install surqlize-*.tgz surrealdb
+          npm install surqlize-*.tgz surrealdb typescript
 
       - name: Copy smoke test scripts
         run: cp tests/smoke/* /tmp/smoke-test/
+
+      - name: Smoke test - TypeScript declarations
+        working-directory: /tmp/smoke-test
+        run: npx tsc --noEmit --skipLibCheck --module nodenext --moduleResolution nodenext type-check.mts
 
       - name: Smoke test - Node.js ESM
         run: node /tmp/smoke-test/node-esm.mjs

--- a/README.md
+++ b/README.md
@@ -995,13 +995,13 @@ const query = db.select("user").return((user) => ({
 type QueryResult = t.infer<typeof query>;
 // QueryResult: Array<{ name: string; age: number }>
 
-// Infer table type
+// Infer table row type
 const userTable = table("user", {
   name: t.string(),
   age: t.number(),
 });
 
-type User = t.infer<typeof userTable>;
+type User = (typeof userTable)["type"];
 // User: { id: RecordId<"user">; name: string; age: number }
 
 // Infer individual type definitions

--- a/src/types/t.ts
+++ b/src/types/t.ts
@@ -101,9 +101,11 @@ export function record<T extends string | undefined>(
 }
 
 /** Extract the inferred TypeScript type from a type definition or workable. */
-export type infer<T extends AbstractType | Workable> =
+type InferType<T extends AbstractType | Workable> =
 	T extends Workable<WorkableContext, infer T>
 		? T["infer"]
 		: T extends AbstractType
 			? T["infer"]
 			: never;
+
+export type { InferType as infer };

--- a/tests/smoke/type-check.mts
+++ b/tests/smoke/type-check.mts
@@ -1,0 +1,21 @@
+import { orm, t, table } from "surqlize";
+import { Surreal } from "surrealdb";
+
+const user = table("user", {
+	name: t.string(),
+	age: t.number(),
+});
+
+const db = orm(new Surreal(), user);
+const query = db.select("user").where((f) => f.age.gte(18)).return((f) => ({
+	name: f.name,
+}));
+
+type QueryResult = t.infer<typeof query>;
+type UserRecord = (typeof user)["type"];
+
+const _result = null as QueryResult | null;
+const _user = null as UserRecord | null;
+
+void _result;
+void _user;

--- a/tests/smoke/type-check.mts
+++ b/tests/smoke/type-check.mts
@@ -1,5 +1,14 @@
 import { orm, t, table } from "surqlize";
-import { Surreal } from "surrealdb";
+import { type RecordId, Surreal } from "surrealdb";
+
+// Strict, invariant type-equality check (not mere assignability), so the
+// assertions below fail if an inferred shape drifts in *either* direction —
+// a missing or extra field is caught, not just an incompatible one.
+type Equal<A, B> =
+	(<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
+		? true
+		: false;
+type Expect<T extends true> = T;
 
 const user = table("user", {
 	name: t.string(),
@@ -7,15 +16,18 @@ const user = table("user", {
 });
 
 const db = orm(new Surreal(), user);
-const query = db.select("user").where((f) => f.age.gte(18)).return((f) => ({
-	name: f.name,
-}));
+const query = db
+	.select("user")
+	.where((f) => f.age.gte(18))
+	.return((f) => ({ name: f.name }));
 
 type QueryResult = t.infer<typeof query>;
 type UserRecord = (typeof user)["type"];
 
-const _result = null as QueryResult | null;
-const _user = null as UserRecord | null;
+// The packaged declarations must parse *and* infer these exact shapes.
+type _AssertQuery = Expect<Equal<QueryResult, { name: string }[]>>;
+type _AssertUser = Expect<
+	Equal<UserRecord, { id: RecordId<"user">; name: string; age: number }>
+>;
 
-void _result;
-void _user;
+void (null as _AssertQuery | _AssertUser | null);


### PR DESCRIPTION
## Summary

This fixes a packaging regression in `surqlize@0.1.0` where the published TypeScript declarations for `t.infer` become syntactically invalid after declaration bundling.

The change keeps the public API unchanged:
- `t.infer<typeof query>` still works the same for consumers

It also adds a post-pack TypeScript smoke test so we validate the packaged tarball, not only the source tree.

## Root Cause

The source currently exposes `t.infer` as a directly declared public type alias:

```ts
export type infer<T extends AbstractType | Workable> = ...
```

This is valid in source, but after declaration bundling the published `dist/index.d.ts` was emitted into an invalid form:

```ts
type t_infer<T extends AbstractType | Workable> = infer<T>;
```

At that point `infer<T>` is parsed as invalid syntax, so any normal TypeScript consumer that imports `surqlize` fails during declaration parsing before regular type-checking.

In other words:
- runtime usage is fine
- source type-check is fine
- published bundled declarations are broken

## What Changed

### 1. Keep `t.infer` public API, change only how it is exported internally

Instead of directly declaring a public type named `infer`, this PR defines an internal type alias and re-exports it as `infer`.

Before:

```ts
export type infer<T extends AbstractType | Workable> = ...
```

After:

```ts
type InferType<T extends AbstractType | Workable> = ...
export type { InferType as infer };
```

This keeps the external API stable while preventing the declaration bundler from emitting the broken `= infer<T>` form.

### 2. Add a packaged TypeScript smoke test

This PR adds a new smoke fixture:

- `tests/smoke/type-check.mts`

It exercises the packaged tarball as a real consumer would:
- imports `orm`, `table`, and `t` from `surqlize`
- builds a query
- uses `t.infer<typeof query>`
- verifies table row typing via `(typeof user)["type"]`

### 3. Run the new smoke test in CI after `npm pack`

The smoke workflow now:
- builds the package
- creates a tarball with `npm pack`
- installs that tarball into an isolated directory
- installs `typescript`
- runs `tsc --noEmit` against the smoke fixture

This closes the gap where source checks passed but packaged declarations were never validated.

### 4. Correct the README table row type example

The README previously showed:

```ts
type User = t.infer<typeof userTable>;
```

That is not actually the supported table-row typing API today, because `table()` returns `TableSchema`, and `t.infer` is defined for `AbstractType | Workable`, not for `TableSchema`.

The table row type is already exposed on `TableSchema["type"]`, so the README now uses:

```ts
type User = (typeof userTable)["type"];
```

This is a documentation correction to match the current library behavior.

## Why This Is Safe

- No runtime behavior changed
- No query-builder behavior changed
- No public `t.infer` consumer syntax changed
- The fix is limited to declaration emission shape and CI coverage

## Validation

Locally verified with:

- `bun run build`
- `bun run type-check`

Packaged-consumer verification:

- `npm pack`
- install tarball into an isolated temp project
- `npx tsc --noEmit --skipLibCheck --module nodenext --moduleResolution nodenext type-check.mts`
- `node node-esm.mjs`
- `node node-cjs.cjs`

The packaged tarball now type-checks successfully and no longer emits the invalid `type t_infer = infer<T>` declaration form.

## Reviewer Notes

The important behavior to review is the packaged declaration output, not only the source diff.

The key guarantee from this PR is:
- users can keep writing `t.infer<typeof ...>`
- published declarations remain parseable
- CI now catches this class of regression before release

