### PR TITLE
Support nested record paths in SELECT FETCH

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,26 @@ const deepFetch = db.select("post")
   .fetch("author", "comments");
 ```
 
+`fetch` also follows nested record paths. Like SurrealDB, fetching a nested
+path expands every record link along the way, and the result type is resolved
+accordingly — `out` becomes the linked record's object, and `out.author`
+expands the `author` link inside it:
+
+```typescript
+// purchased is an edge: user ->purchased-> product, and product.author -> author
+const purchases = await db.select("purchased")
+  .fetch("out", "out.author")
+  .execute();
+
+purchases[0].out.title;        // string  (product fetched)
+purchases[0].out.author.name;  // string  (nested author fetched)
+purchases[0].in;               // RecordId<"user">  (left as a link)
+```
+
+Record links wrapped in `option<…>` or `array<…>` are resolved too, so
+`fetch("tags")` on an `array<record<tag>>` field yields an array of full `tag`
+objects.
+
 #### Splitting arrays with SPLIT
 
 ```typescript

--- a/src/query/select.ts
+++ b/src/query/select.ts
@@ -2,8 +2,10 @@ import { type RecordId, Table } from "surrealdb";
 import type { Orm } from "../schema/orm.ts";
 import {
 	type AbstractType,
-	type ArrayType,
+	ArrayType,
 	ObjectType,
+	type ObjectTypeInner,
+	OptionType,
 	RecordType,
 	t,
 } from "../types";
@@ -30,23 +32,84 @@ type FieldKeys<O extends Orm, T extends keyof O["tables"] & string> =
 		? keyof F & string
 		: string;
 
-/** Resolve a single field type: if it's a RecordType referencing a known table, replace with that table's schema. */
-type ResolveField<O extends Orm, F extends AbstractType> =
+/**
+ * Every valid FETCH path for a table: a top-level field, or a dotted path
+ * rooted at a top-level field (e.g. `"out"` or `"out.author"`). Only the head
+ * segment is constrained to a known field; deeper segments are unconstrained,
+ * mirroring SurrealDB which validates the rest of the path at query time.
+ */
+type FetchPaths<O extends Orm, T extends keyof O["tables"] & string> =
+	| FieldKeys<O, T>
+	| `${FieldKeys<O, T>}.${string}`;
+
+/** The first segment of a dotted path, or the whole path when it has no dot. */
+type PathHead<P extends string> = P extends `${infer H}.${string}` ? H : P;
+
+/** The remainder of every path whose head segment is `K`. */
+type PathTail<K extends string, P extends string> = P extends `${K}.${infer R}`
+	? R
+	: never;
+
+/**
+ * Resolve a record link to the schema it points at, unwrapping `option<…>` and
+ * `array<…>` wrappers. Non-record types (and records to unknown tables) are
+ * left untouched.
+ */
+type ResolveLink<O extends Orm, F extends AbstractType> =
 	F extends RecordType<infer Tb>
 		? Tb extends keyof O["tables"] & string
 			? O["tables"][Tb]["schema"]
 			: F
-		: F;
+		: F extends OptionType<infer Inner extends AbstractType>
+			? OptionType<ResolveLink<O, Inner>>
+			: F extends ArrayType<infer Inner extends AbstractType>
+				? ArrayType<ResolveLink<O, Inner>>
+				: F;
 
-/** Transform an ObjectType by resolving RecordType fields that appear in the Fields union. */
+/**
+ * Resolve a record link and then continue fetching `Tails` within the resolved
+ * object. Used when a fetch path descends past this field (e.g. `out.author`
+ * descends through `out`).
+ */
+type ResolveNested<
+	O extends Orm,
+	F extends AbstractType,
+	Tails extends string,
+> =
+	F extends RecordType<infer Tb>
+		? Tb extends keyof O["tables"] & string
+			? FetchedSchema<O, O["tables"][Tb]["schema"], Tails>
+			: F
+		: F extends OptionType<infer Inner extends AbstractType>
+			? OptionType<ResolveNested<O, Inner, Tails>>
+			: F extends ArrayType<infer Inner extends AbstractType>
+				? ArrayType<ResolveNested<O, Inner, Tails>>
+				: F extends ObjectType<ObjectTypeInner>
+					? FetchedSchema<O, F, Tails>
+					: F;
+
+/** Resolve a single fetched field given the nested paths (if any) beneath it. */
+type FetchField<O extends Orm, F extends AbstractType, Tails extends string> = [
+	Tails,
+] extends [never]
+	? ResolveLink<O, F>
+	: ResolveNested<O, F, Tails>;
+
+/**
+ * Transform an ObjectType by resolving every fetched field. A field is resolved
+ * when it is the head of any fetch path; nested paths recurse into the resolved
+ * schema. Matches SurrealDB, which expands intermediate records along a path.
+ */
 type FetchedSchema<
 	O extends Orm,
 	E extends AbstractType,
-	Fields extends string,
+	Paths extends string,
 > =
 	E extends ObjectType<infer S>
 		? ObjectType<{
-				[K in keyof S]: K extends Fields ? ResolveField<O, S[K]> : S[K];
+				[K in keyof S]: K extends PathHead<Paths>
+					? FetchField<O, S[K], PathTail<K & string, Paths>>
+					: S[K];
 			}>
 		: E;
 
@@ -213,33 +276,27 @@ export class SelectQuery<
 		return this;
 	}
 
-	fetch<F extends FieldKeys<O, T>>(
-		...fields: (F | `${F}.${string}`)[]
-	): SelectQuery<O, C, T, FetchedSchema<O, E, F>> {
+	fetch<P extends FetchPaths<O, T>>(
+		...fields: P[]
+	): SelectQuery<O, C, T, FetchedSchema<O, E, P>> {
 		this._fetch = fields;
 
-		// Build a resolved schema where fetched RecordType fields are replaced
-		// with the referenced table's ObjectType schema, so parse() validates
-		// the resolved objects instead of expecting RecordIds.
+		// Build a resolved schema where fetched record references are replaced
+		// with the referenced table's ObjectType schema, recursing into nested
+		// paths so parse() validates the resolved objects instead of expecting
+		// RecordIds. SurrealDB expands every record along a fetched path, so
+		// `out.author` resolves both `out` and its nested `author`.
 		const currentSchema =
 			this._entry?.[__type] ?? this[__ctx].orm.tables[this.tb]!.schema;
 		if (currentSchema instanceof ObjectType) {
-			const resolved = { ...currentSchema.schema };
-			for (const field of fields) {
-				// Only resolve top-level field names (ignore "field.nested" paths)
-				const topLevel = field.includes(".") ? field.split(".")[0]! : field;
-				const fieldType = resolved[topLevel];
-				if (fieldType instanceof RecordType && fieldType.tb) {
-					const targetTable = this[__ctx].orm.tables[fieldType.tb as string];
-					if (targetTable) {
-						resolved[topLevel] = targetTable.schema;
-					}
-				}
-			}
-			this._fetchResolvedType = new ObjectType(resolved);
+			this._fetchResolvedType = resolveFetchObject(
+				currentSchema,
+				fields,
+				this[__ctx].orm,
+			);
 		}
 
-		return this as unknown as SelectQuery<O, C, T, FetchedSchema<O, E, F>>;
+		return this as unknown as SelectQuery<O, C, T, FetchedSchema<O, E, P>>;
 	}
 
 	timeout(duration: string): this {
@@ -313,4 +370,63 @@ export class SelectQuery<
 
 		return `(${query})`;
 	}
+}
+
+/**
+ * Resolve the fetched fields of an object schema at runtime, mirroring
+ * {@link FetchedSchema} at the value level. Fetch paths are grouped by their
+ * head segment; each head is resolved once and any deeper segments recurse into
+ * the resolved schema.
+ */
+function resolveFetchObject(
+	schema: ObjectType,
+	paths: string[],
+	orm: Orm,
+): ObjectType {
+	// Group paths by head segment, collecting the remaining (nested) paths.
+	const tailsByHead = new Map<string, string[]>();
+	for (const path of paths) {
+		const dot = path.indexOf(".");
+		const head = dot === -1 ? path : path.slice(0, dot);
+		const tail = dot === -1 ? undefined : path.slice(dot + 1);
+		const tails = tailsByHead.get(head) ?? [];
+		if (tail !== undefined) tails.push(tail);
+		tailsByHead.set(head, tails);
+	}
+
+	const resolved: ObjectTypeInner = { ...schema.schema };
+	for (const [head, tails] of tailsByHead) {
+		const fieldType = resolved[head];
+		if (fieldType) resolved[head] = resolveFetchField(fieldType, tails, orm);
+	}
+	return new ObjectType(resolved);
+}
+
+/**
+ * Resolve a single fetched field: expand record links (unwrapping `option<…>`
+ * and `array<…>`) to the referenced table's schema, then continue resolving any
+ * nested paths within it. Unknown or non-record fields are returned unchanged.
+ */
+function resolveFetchField(
+	fieldType: AbstractType,
+	tails: string[],
+	orm: Orm,
+): AbstractType {
+	if (fieldType instanceof RecordType && fieldType.tb) {
+		const target = orm.tables[fieldType.tb as string];
+		if (!target) return fieldType;
+		return tails.length === 0
+			? target.schema
+			: resolveFetchObject(target.schema, tails, orm);
+	}
+	if (fieldType instanceof OptionType) {
+		return new OptionType(resolveFetchField(fieldType.schema, tails, orm));
+	}
+	if (fieldType instanceof ArrayType && !Array.isArray(fieldType.schema)) {
+		return new ArrayType(resolveFetchField(fieldType.schema, tails, orm));
+	}
+	if (fieldType instanceof ObjectType && tails.length > 0) {
+		return resolveFetchObject(fieldType, tails, orm);
+	}
+	return fieldType;
 }

--- a/tests/integration/fetch.test.ts
+++ b/tests/integration/fetch.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import { RecordId } from "surrealdb";
+import { edge, orm, t, table } from "../../src";
+import { withTestDb } from "./setup";
+
+// Reproduces https://github.com/surrealdb/surqlize/issues/22 — fetching nested
+// record references such as `out` and `out.author` on an edge table.
+describe("nested FETCH integration tests", () => {
+	const author = table("author", {
+		name: t.string(),
+	});
+
+	const product = table("product", {
+		title: t.string(),
+		author: t.record("author"),
+	});
+
+	const purchased = edge("user", "purchased", "product", {
+		moment: t.date(),
+	});
+
+	const getTestDb = withTestDb({
+		setup: async ({ surreal }) => {
+			await surreal.query(`
+				CREATE author:alice SET name = "Alice";
+				CREATE product:widget SET title = "Widget", author = author:alice;
+				RELATE user:bob->purchased->product:widget SET moment = time::now();
+			`);
+		},
+	});
+
+	test("resolves nested record references (out, out.author)", async () => {
+		const { surreal } = getTestDb();
+		const db = orm(surreal, author, product, purchased);
+
+		const result = await db
+			.select("purchased")
+			.fetch("out", "out.author")
+			.execute();
+
+		expect(result.length).toBe(1);
+		const row = result[0]!;
+
+		// `out` is expanded into the full product object
+		expect(row.out.title).toBe("Widget");
+		// `out.author` is expanded into the full author object
+		expect(row.out.author.name).toBe("Alice");
+		// `in` is left as a record link
+		expect(row.in).toBeInstanceOf(RecordId);
+		expect(String(row.in)).toBe("user:bob");
+	});
+
+	test("fetching only `out` leaves the nested author as a record link", async () => {
+		const { surreal } = getTestDb();
+		const db = orm(surreal, author, product, purchased);
+
+		const result = await db.select("purchased").fetch("out").execute();
+
+		expect(result.length).toBe(1);
+		const out = result[0]!.out;
+		expect(out.title).toBe("Widget");
+		// Not fetched -> remains a RecordId
+		expect(out.author).toBeInstanceOf(RecordId);
+		expect(String(out.author)).toBe("author:alice");
+	});
+});

--- a/tests/unit/query/select.test.ts
+++ b/tests/unit/query/select.test.ts
@@ -4,6 +4,7 @@ import {
 	__display,
 	and,
 	displayContext,
+	edge,
 	or,
 	orm,
 	t,
@@ -432,6 +433,138 @@ describe("SELECT FETCH", () => {
 		const result = query[__display](ctx);
 
 		expect(result).toContain("FETCH author.profile");
+	});
+});
+
+describe("SELECT FETCH nested resolution", () => {
+	const author = table("author", {
+		name: t.string(),
+	});
+
+	const product = table("product", {
+		title: t.string(),
+		author: t.record("author"),
+		tags: t.array(t.record("author")),
+		featured: t.option(t.record("author")),
+	});
+
+	const purchased = edge("user", "purchased", "product", {
+		moment: t.date(),
+	});
+
+	const db = orm(new Surreal(), author, product, purchased);
+
+	const authorRid = new RecordId("author", "alice");
+	const productRid = new RecordId("product", "widget");
+	const userRid = new RecordId("user", "bob");
+	const purchasedRid = new RecordId("purchased", "x");
+	const authorObj = { id: authorRid, name: "Alice" };
+
+	test("fetching a record link expands it but leaves nested links alone", () => {
+		const query = db.select("purchased").fetch("out");
+
+		const fetchedNestedLinks = {
+			id: purchasedRid,
+			in: userRid,
+			out: {
+				id: productRid,
+				title: "Widget",
+				author: authorRid,
+				tags: [],
+				featured: undefined,
+			},
+			moment: new Date(),
+		};
+		expect(query.entry.validate(fetchedNestedLinks)).toBe(true);
+
+		// `out` must be an object now, not a RecordId
+		const unfetchedOut = { ...fetchedNestedLinks, out: productRid };
+		expect(query.entry.validate(unfetchedOut)).toBe(false);
+	});
+
+	test("fetching a nested path (out.author) expands the whole chain", () => {
+		const query = db.select("purchased").fetch("out", "out.author");
+
+		const fullyFetched = {
+			id: purchasedRid,
+			in: userRid,
+			out: {
+				id: productRid,
+				title: "Widget",
+				author: authorObj,
+				tags: [],
+				featured: undefined,
+			},
+			moment: new Date(),
+		};
+		expect(query.entry.validate(fullyFetched)).toBe(true);
+
+		// Leaving the nested author as a RecordId must now fail validation
+		const nestedStillLink = {
+			...fullyFetched,
+			out: { ...fullyFetched.out, author: authorRid },
+		};
+		expect(query.entry.validate(nestedStillLink)).toBe(false);
+	});
+
+	test("fetching out.author alone still expands the intermediate out", () => {
+		// SurrealDB expands every record along a fetched path.
+		const query = db.select("purchased").fetch("out.author");
+
+		const sample = {
+			id: purchasedRid,
+			in: userRid,
+			out: {
+				id: productRid,
+				title: "Widget",
+				author: authorObj,
+				tags: [],
+				featured: undefined,
+			},
+			moment: new Date(),
+		};
+		expect(query.entry.validate(sample)).toBe(true);
+
+		const outNotExpanded = { ...sample, out: productRid };
+		expect(query.entry.validate(outNotExpanded)).toBe(false);
+	});
+
+	test("resolves record links inside array and option wrappers", () => {
+		const query = db.select("product").fetch("tags", "featured");
+
+		const sample = {
+			id: productRid,
+			title: "Widget",
+			author: authorRid, // not fetched -> stays a RecordId
+			tags: [authorObj, { id: new RecordId("author", "bob"), name: "Bob" }],
+			featured: authorObj,
+		};
+		expect(query.entry.validate(sample)).toBe(true);
+
+		// option<record> resolves to option<author> — undefined is still valid
+		const noneFeatured = { ...sample, featured: undefined };
+		expect(query.entry.validate(noneFeatured)).toBe(true);
+
+		// array elements must be expanded objects, not RecordIds
+		const tagsStillLinks = { ...sample, tags: [authorRid] };
+		expect(query.entry.validate(tagsStillLinks)).toBe(false);
+	});
+
+	test("result type reflects the resolved nested shape", () => {
+		const query = db.select("purchased").fetch("out", "out.author");
+		type Row = t.infer<typeof query>[number];
+
+		// Compile-only assertions: this function is never invoked, so the nested
+		// property accesses are type-checked without running. They only compile
+		// when `out` and `out.author` resolve to objects and `in` stays a link.
+		const typeAssertions = (row: Row) => {
+			const title: string = row.out.title;
+			const name: string = row.out.author.name;
+			const inLink: RecordId<"user"> = row.in;
+			return [title, name, inLink];
+		};
+
+		expect(typeof typeAssertions).toBe("function");
 	});
 });
 


### PR DESCRIPTION
Fixes #22.

## Problem

`fetch()` only resolved **top-level** record fields. A nested path such as:

```ts
db.select("purchased").fetch("out", "out.author")
```

left the nested `author` field typed and validated as `RecordId<author>`, even though SurrealDB had already expanded it into an object during the fetch. The result was the runtime error from the issue:

```
Expected RecordId<author> but found [object Object]
```

Nested fetching is a core SurrealDB strength, so this was a notable gap.

## Behavior (verified against a live SurrealDB)

- `FETCH out.author` expands **every** record along the path — both `out` and its nested `author`.
- `FETCH out` alone expands `out` but leaves `out.author` as a link.

## Fix (`src/query/select.ts`)

- **Runtime:** fetch paths are grouped by head segment and resolved recursively (`resolveFetchObject` / `resolveFetchField`), expanding record links to the referenced table's schema and descending into nested paths. `option<…>` and `array<…>` wrappers are unwrapped and nested objects are traversed, so e.g. `fetch("tags")` on `array<record<tag>>` yields full `tag` objects.
- **Types:** the `fetch<P extends FetchPaths<O, T>>(...fields: P[])` signature now captures the full dotted-path literals (`"out" | "out.author"`), and `FetchedSchema` mirrors the runtime resolution via `PathHead` / `PathTail` + `ResolveLink` / `ResolveNested`. So `row.out.title` and `row.out.author.name` are fully typed while unfetched links like `row.in` stay `RecordId<"user">`.

## Tests

- New integration test (`tests/integration/fetch.test.ts`) reproducing the issue's exact scenario (`user ->purchased-> product`, `product.author -> author`). Confirmed it fails on the old code with the reported error and passes with the fix.
- New unit tests covering nested chains, fetching an intermediate path alone, and `array` / `option` record wrappers, plus a compile-only type-level assertion.
- Full suite green: **597 pass / 0 fail**, `tsc --noEmit` clean, Biome clean.

## Reviewer notes

- Only the **head** segment of a fetch path is constrained to a known field; deeper segments accept any string (SurrealDB validates the rest at query time). Deep key-level autocomplete would be a much larger type-system change and could be a follow-up.
- Integration tests need a local SurrealDB on `ws://localhost:8000` (root/root).

## Docs

Updated the README's FETCH section with a nested-fetch example.