### PR TITLE
Fix .fetch() + .return() projections (#23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,17 @@ const withAuthor = db.select("post")
 // Fetch multiple relations
 const deepFetch = db.select("post")
   .fetch("author", "comments");
+
+// Project a subset of a fetched relation with RETURN. The result is typed and
+// validated against the projected shape, so you can pick fields from the linked
+// records (in / out) and omit the edge's own fields without errors.
+const authorships = db.select("authored")
+  .fetch("in", "out")
+  .return((edge) => ({
+    user: edge.in.name,   // from the fetched `user` record
+    post: edge.out.title, // from the fetched `post` record
+    role: edge.role,
+  }));
 ```
 
 #### Splitting arrays with SPLIT

--- a/src/query/select.ts
+++ b/src/query/select.ts
@@ -98,8 +98,14 @@ export class SelectQuery<
 	}
 
 	get entry(): E {
-		return (this._fetchResolvedType ??
-			this._entry?.[__type] ??
+		// A return projection (`_entry`) defines the query's result shape, so it
+		// must take precedence over the fetch-resolved schema when both are set —
+		// otherwise parse() would validate the projection against the full table
+		// schema and reject it for missing (unprojected) fields. The `.return()`
+		// callback still sees the fetch-resolved schema because it reads `entry`
+		// *before* assigning `_entry`.
+		return (this._entry?.[__type] ??
+			this._fetchResolvedType ??
 			this[__ctx].orm.tables[this.tb]!.schema) as E;
 	}
 

--- a/src/types/classes.ts
+++ b/src/types/classes.ts
@@ -1,6 +1,24 @@
 import { RecordId, Uuid } from "surrealdb";
 import { TypeParseError } from "../error";
 
+/** Matches strings usable as a bare SurrealQL identifier in an idiom path. */
+const IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/**
+ * Build an idiom path segment for accessing `prop` on a parent value.
+ *
+ * String keys that are valid identifiers use dot notation (`.name`). This is
+ * required for record-link traversal: SurrealDB dereferences links through the
+ * `.` operator (`record.field`) but NOT through index access (`record["field"]`),
+ * which returns NONE. Dot notation also works for plain object fields, so it is
+ * the correct default. Non-identifier keys (and numeric indices, handled by the
+ * caller) fall back to bracket notation.
+ */
+function pathSegment(prop: string | number): string {
+	if (typeof prop === "string" && IDENTIFIER.test(prop)) return `.${prop}`;
+	return `[${JSON.stringify(prop)}]`;
+}
+
 export abstract class AbstractType<T = unknown> {
 	abstract readonly name: string;
 	abstract readonly expected: string | [string, string, ...string[]];
@@ -21,7 +39,7 @@ export abstract class AbstractType<T = unknown> {
 	}
 
 	get(prop: string | number): [AbstractType, string] {
-		return [new NoneType(), `[${JSON.stringify(prop)}]`];
+		return [new NoneType(), pathSegment(prop)];
 	}
 }
 
@@ -244,10 +262,10 @@ export class ObjectType<
 
 	get(prop: string | number): [AbstractType, string] {
 		if (prop in this.schema) {
-			return [this.schema[prop as keyof T]!, `[${JSON.stringify(prop)}]`];
+			return [this.schema[prop as keyof T]!, pathSegment(prop)];
 		}
 
-		return [new NoneType(), `[${JSON.stringify(prop)}]`];
+		return [new NoneType(), pathSegment(prop)];
 	}
 }
 

--- a/tests/integration/return-projections.test.ts
+++ b/tests/integration/return-projections.test.ts
@@ -220,6 +220,63 @@ describe("Return projection integration tests", () => {
 				expect(row.length).toBe(2);
 			}
 		});
+
+		// Regression tests for https://github.com/surrealdb/surqlize/issues/23 —
+		// a return projection over a graph edge must (1) validate against the
+		// projected shape rather than the full edge schema, so omitting the edge's
+		// own fields (created/updated) is fine, and (2) traverse the in/out record
+		// links via dot notation so nested fields actually resolve.
+
+		test("FETCH + RETURN { ... } — project subset of an edge, omitting edge fields", async () => {
+			const { db } = getTestDb();
+			const result = await db
+				.select("authored")
+				.fetch("in", "out")
+				.return((p) => ({
+					user: {
+						first: p.in.name.first,
+						id: p.in.id,
+					},
+					edge_id: p.id,
+					post: {
+						title: p.out.title,
+						id: p.out.id,
+					},
+				}))
+				.execute();
+
+			expect(result.length).toBe(2);
+			for (const row of result) {
+				expect(typeof row.user.first).toBe("string");
+				expect(String(row.user.id)).toContain("user:");
+				expect(String(row.edge_id)).toContain("authored:");
+				expect(typeof row.post.title).toBe("string");
+				expect(String(row.post.id)).toContain("post:");
+			}
+
+			const sorted = result.sort((a, b) =>
+				a.user.first.localeCompare(b.user.first),
+			);
+			expect(sorted[0]!.user.first).toBe("Alice");
+			expect(sorted[0]!.post.title).toBe("First Post");
+			expect(sorted[1]!.user.first).toBe("Bob");
+			expect(sorted[1]!.post.title).toBe("Second Post");
+		});
+
+		test("FETCH + RETURN { ... } — mixes a fetched link field with an edge field", async () => {
+			const { db } = getTestDb();
+			const result = await db
+				.select("authored")
+				.fetch("in")
+				.return((p) => ({ author: p.in.email, when: p.created }))
+				.execute();
+
+			expect(result.length).toBe(2);
+			for (const row of result) {
+				expect(row.author).toContain("@example.com");
+				expect(row.when).toBeDefined();
+			}
+		});
 	});
 
 	// ─── CREATE ────────────────────────────────────────────────────────────

--- a/tests/unit/query/return-projections.test.ts
+++ b/tests/unit/query/return-projections.test.ts
@@ -33,7 +33,7 @@ describe("SELECT return projections", () => {
 		const result = query[__display](ctx);
 
 		expect(result).toContain("SELECT VALUE");
-		expect(result).toContain('$this["name"]');
+		expect(result).toContain("$this.name");
 	});
 
 	test("RETURN VALUE <nested field> — nested field access", () => {
@@ -42,7 +42,7 @@ describe("SELECT return projections", () => {
 		const result = query[__display](ctx);
 
 		expect(result).toContain("SELECT VALUE");
-		expect(result).toContain('$this["name"]["first"]');
+		expect(result).toContain("$this.name.first");
 	});
 
 	test("RETURN { ... } — flat object", () => {
@@ -80,7 +80,7 @@ describe("SELECT return projections", () => {
 		const result = query[__display](ctx);
 
 		expect(result).toContain("SELECT VALUE");
-		expect(result).toMatch(/\[.*\$this\["name"\].*,.*\$this\["age"\].*\]/);
+		expect(result).toMatch(/\[.*\$this\.name.*,.*\$this\.age.*\]/);
 	});
 
 	test("RETURN [ ... ] — array with nested field access", () => {
@@ -92,9 +92,9 @@ describe("SELECT return projections", () => {
 
 		expect(result).toContain("SELECT VALUE");
 		expect(result).toContain("[");
-		expect(result).toContain('$this["name"]["first"]');
-		expect(result).toContain('$this["name"]["last"]');
-		expect(result).toContain('$this["age"]');
+		expect(result).toContain("$this.name.first");
+		expect(result).toContain("$this.name.last");
+		expect(result).toContain("$this.age");
 		expect(result).toContain("]");
 	});
 
@@ -160,7 +160,7 @@ describe("CREATE return projections", () => {
 
 		expect(result).toContain("CREATE");
 		expect(result).toContain("RETURN VALUE");
-		expect(result).toContain('$this["name"]');
+		expect(result).toContain("$this.name");
 	});
 
 	test("RETURN VALUE { ... } — object", () => {
@@ -234,7 +234,7 @@ describe("UPDATE return projections", () => {
 
 		expect(result).toContain("UPDATE");
 		expect(result).toContain("RETURN VALUE");
-		expect(result).toContain('$this["name"]');
+		expect(result).toContain("$this.name");
 	});
 
 	test("RETURN VALUE { ... } — object", () => {
@@ -260,9 +260,9 @@ describe("UPDATE return projections", () => {
 
 		expect(result).toContain("RETURN VALUE");
 		expect(result).toContain("[");
-		expect(result).toContain('$this["name"]["first"]');
-		expect(result).toContain('$this["age"]');
-		expect(result).toContain('$this["email"]');
+		expect(result).toContain("$this.name.first");
+		expect(result).toContain("$this.age");
+		expect(result).toContain("$this.email");
 		expect(result).toContain("]");
 	});
 
@@ -307,7 +307,7 @@ describe("UPSERT return projections", () => {
 
 		expect(result).toContain("UPSERT");
 		expect(result).toContain("RETURN VALUE");
-		expect(result).toContain('$this["email"]');
+		expect(result).toContain("$this.email");
 	});
 
 	test("RETURN VALUE { ... } — object", () => {
@@ -357,7 +357,7 @@ describe("INSERT return projections", () => {
 
 		expect(result).toContain("INSERT");
 		expect(result).toContain("RETURN VALUE");
-		expect(result).toContain('$this["email"]');
+		expect(result).toContain("$this.email");
 	});
 
 	test("RETURN VALUE { ... } — object", () => {
@@ -395,7 +395,7 @@ describe("DELETE return projections", () => {
 
 		expect(result).toContain("DELETE");
 		expect(result).toContain("RETURN VALUE");
-		expect(result).toContain('$this["name"]');
+		expect(result).toContain("$this.name");
 	});
 
 	test("RETURN VALUE { ... } — object", () => {

--- a/tests/unit/query/select.test.ts
+++ b/tests/unit/query/select.test.ts
@@ -243,7 +243,7 @@ describe("SELECT ORDER BY", () => {
 		const result = query[__display](ctx);
 
 		expect(result).toContain("ORDER BY");
-		expect(result).toContain('["name"]["last"]');
+		expect(result).toContain(".name.last");
 		expect(result).toContain("ASC");
 	});
 
@@ -256,8 +256,8 @@ describe("SELECT ORDER BY", () => {
 		const result = query[__display](ctx);
 
 		expect(result).toContain("ORDER BY");
-		expect(result).toContain('["name"]["last"] ASC');
-		expect(result).toContain('["name"]["first"] ASC');
+		expect(result).toContain(".name.last ASC");
+		expect(result).toContain(".name.first ASC");
 		// Both should be in a single ORDER BY clause separated by comma
 		expect(result).toMatch(/ORDER BY .+, .+/);
 	});

--- a/tests/unit/types/t.test.ts
+++ b/tests/unit/types/t.test.ts
@@ -329,14 +329,14 @@ describe("Type builders", () => {
 			const type = t.object({ name: t.string(), age: t.number() });
 			const [fieldType, path] = type.get("name");
 			expect(fieldType.name).toBe("string");
-			expect(path).toBe('["name"]');
+			expect(path).toBe(".name");
 		});
 
 		test("ObjectType.get() returns NoneType for unknown key", () => {
 			const type = t.object({ name: t.string() });
 			const [fieldType, path] = type.get("unknown");
 			expect(fieldType).toBeInstanceOf(NoneType);
-			expect(path).toBe('["unknown"]');
+			expect(path).toBe(".unknown");
 		});
 
 		test("ArrayType.get() returns element type for tuple index", () => {
@@ -363,7 +363,7 @@ describe("Type builders", () => {
 			const type = t.string();
 			const [fieldType, path] = type.get("anything");
 			expect(fieldType).toBeInstanceOf(NoneType);
-			expect(path).toBe('["anything"]');
+			expect(path).toBe(".anything");
 		});
 	});
 

--- a/tests/unit/utils/workable.test.ts
+++ b/tests/unit/utils/workable.test.ts
@@ -89,7 +89,7 @@ describe("workableGet", () => {
 
 		const child = workableGet(parentWorkable, "name");
 		const display = child[__display](ctx);
-		expect(display).toBe('$this["name"]');
+		expect(display).toBe("$this.name");
 	});
 
 	test("returns correct type for known property", () => {


### PR DESCRIPTION
Closes #23.

## Problem

Using `.fetch()` together with `.return()` to project a subset of a fetched relation failed. For example, projecting an edge while omitting its own date fields threw `Expected Date but found undefined`, and the projected nested objects (the fetched `in`/`out` records) came back empty.

Reproduced exactly against SurrealDB 3.1.2. There were **two** distinct bugs:

### 1. `parse()` validated against the wrong schema

In `SelectQuery`, the `entry` getter — which drives result parsing — checked the fetch-resolved schema **before** the `.return()` projection. Because `.fetch()` runs first, `parse()` kept validating the projected result against the *full edge schema* (demanding `created`/`updated`/`in`/`out`), even though the generated SurrealQL was correct.

**Fix:** the projection (`_entry`) now takes precedence over the fetch-resolved schema. The `.return()` callback still sees the fetch-resolved schema, because it reads `entry` *before* the projection is assigned.

### 2. Field access didn't traverse record links

Field access generated bracket notation (`$this["in"]["name"]`). Verified directly against SurrealDB: bracket/index access does **not** dereference record links (returns `NONE`), while the dot operator does:

```
in.name.first          → "Alice"   ✓
$this["in"]["name"]... → null       ✗
```

That's why the projected `user`/`post` objects came back empty `{}` (SurrealDB drops `NONE` fields).

**Fix:** a `pathSegment` helper emits dot notation (`$this.in.name`) for identifier-safe keys — which traverses both plain object fields and record links — and falls back to bracket notation for non-identifier keys and numeric (array) indices.

## Result

The issue's exact query now works and returns fully-populated, correctly-typed rows:

```
SELECT VALUE { user: { first: $this.in.name.first, id: $this.in.id }, edge_id: $this.id, post: { title: $this.out.title, id: $this.out.id } } FROM ... FETCH in, out
```

## Testing

- Added integration regression tests in `tests/integration/return-projections.test.ts` covering the issue scenario (fetch + project a subset omitting edge fields; mixing a fetched link field with an edge field).
- Updated unit-test display assertions to the new dot notation.
- `bun test` → 592 pass, 0 fail; `bun run type-check` and `biome check .` both clean.
- Added a README example under the FETCH section.

## Reviewer notes

- The dot-vs-bracket change affects **all** generated field-access idioms (WHERE, ORDER BY, RETURN), not just projections — dot notation is the idiomatic SurrealQL form and also fixes link traversal. Numeric/array indexing is unchanged.
- Note: record-link subfields are only type-resolved (and therefore parseable) when `.fetch()` resolves the linked table; without `.fetch()` they remain `NoneType`. This matches the existing design.
- Out of scope here: nested `Date` fields in projections currently return raw SurrealDB datetimes rather than JS `Date`s, because `ObjectType.parse`/`ArrayType.parse` discard the converted value. Worth a separate follow-up.