### PR TITLE
Support passing schemas to `orm()` as an object

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,54 @@ const db = orm(new Surreal(), user, post, authored);
 - `in`: RecordId of the source table (user)
 - `out`: RecordId of the target table (post)
 
+## Registering schemas
+
+Pass your tables and edges to `orm()` to get a type-safe client. Schemas can be
+supplied either as individual arguments or grouped in a single object — both
+produce an identical, fully typed ORM:
+
+```typescript
+// As individual arguments
+const db = orm(new Surreal(), user, post, authored);
+
+// Or grouped in an object
+const db = orm(new Surreal(), { user, post, authored });
+```
+
+The object form pairs nicely with a dedicated schema module, letting you define
+your tables once and reuse them across multiple ORM instances:
+
+```typescript
+// database/schema.ts
+import { edge, t, table } from "surqlize";
+
+export const user = table("user", {
+  name: t.string(),
+  email: t.string(),
+});
+
+export const post = table("post", {
+  title: t.string(),
+  content: t.string(),
+});
+
+export const authored = edge("user", "authored", "post", {
+  created: t.date(),
+});
+```
+
+```typescript
+// src/db.ts
+import { Surreal } from "surrealdb";
+import { orm } from "surqlize";
+import * as schema from "../database/schema";
+
+const db = orm(new Surreal(), schema);
+```
+
+> Tables are always addressed by their `tb` name in queries (e.g. `db.select("user")`),
+> regardless of how they are registered. The object keys are purely organizational.
+
 ## CRUD Operations
 
 ### SELECT statements

--- a/src/schema/orm.ts
+++ b/src/schema/orm.ts
@@ -18,7 +18,7 @@ import type { ApiEndpointSchema } from "./api";
 import { EdgeSchema } from "./edge";
 import type { FunctionCallable, InferParams } from "./function";
 import { type CreateSchemaLookup, createLookupFromSchemas } from "./lookup";
-import type { TableSchema } from "./table";
+import { TableSchema } from "./table";
 
 /** Union type representing any table or edge schema. */
 export type AnyTable<Tb extends string = string> =
@@ -29,6 +29,39 @@ export type AnyTable<Tb extends string = string> =
 export type MappedTables<T extends AnyTable[]> = {
 	[K in T[number]["tb"]]: Extract<T[number], AnyTable<K>>;
 } & {};
+
+/**
+ * A plain object grouping table/edge schemas under arbitrary keys, e.g. the
+ * result of `import * as schema from "./schema"`. The object keys are only a
+ * container — tables are still addressed by their `tb` name in queries.
+ */
+export type SchemaMap = Record<string, AnyTable>;
+
+// Convert the union of a schema map's values into a tuple so the object form of
+// `orm()` resolves to exactly the same `Orm<[...]>` type as the rest-param form.
+// Element order is irrelevant: every consumer (`MappedTables`, the lookup
+// helpers, `HasEdgeSchema`) inspects the tuple via `[number]` or a membership
+// check — none depend on ordering.
+type UnionToIntersection<U> = (
+	U extends unknown
+		? (k: U) => void
+		: never
+) extends (k: infer I) => void
+	? I
+	: never;
+
+type LastOf<U> =
+	UnionToIntersection<U extends unknown ? () => U : never> extends () => infer R
+		? R
+		: never;
+
+type UnionToTuple<U> = [U] extends [never]
+	? []
+	: [...UnionToTuple<Exclude<U, LastOf<U>>>, LastOf<U>];
+
+/** The schemas held by a {@link SchemaMap}, as a tuple used as the `Orm` type argument. */
+export type SchemaMapTables<S extends SchemaMap> =
+	UnionToTuple<S[keyof S]> extends infer R extends AnyTable[] ? R : never;
 
 /**
  * The main ORM entry point. Provides type-safe query builders for all
@@ -402,33 +435,72 @@ export class Orm<T extends AnyTable[] = AnyTable[]> {
 }
 
 /**
+ * Distinguish a {@link SchemaMap} from an individual table/edge schema. A single
+ * schema is an instance of {@link TableSchema} or {@link EdgeSchema}; a schema map
+ * is any other (plain) object.
+ */
+function isSchemaMap(value: unknown): value is SchemaMap {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		!(value instanceof TableSchema) &&
+		!(value instanceof EdgeSchema)
+	);
+}
+
+/**
  * Create an ORM instance bound to a SurrealDB session and a set of table/edge
  * schemas. This is the main entry point for building type-safe queries.
+ *
+ * Schemas may be passed either as individual arguments or grouped in a single
+ * object — both produce an identical, fully typed ORM. Tables are always
+ * addressed by their `tb` name in queries, regardless of how they are passed.
  *
  * @param surreal - An active SurrealDB session.
  * @param tables - One or more {@link TableSchema} or {@link EdgeSchema} definitions.
  * @returns An {@link Orm} instance with query builders scoped to the provided schemas.
  *
- * @example
+ * @example Individual arguments
  * ```ts
  * const db = orm(new Surreal(), user, post, authored);
+ * const users = await db.select("user");
+ * ```
+ *
+ * @example A schema object (handy with `import * as schema`)
+ * ```ts
+ * // database/schema.ts
+ * export const user = table("user", { name: t.string() });
+ * export const post = table("post", { title: t.string() });
+ *
+ * // src/db.ts
+ * import * as schema from "../database/schema";
+ * const db = orm(new Surreal(), schema);
  * const users = await db.select("user");
  * ```
  */
 export function orm<T extends AnyTable[]>(
 	surreal: SurrealSession,
 	...tables: T
-) {
-	const mapped = tables.reduce<MappedTables<T>>(
-		(acc, table) => {
-			const key = table.tb as T[number]["tb"];
-			acc[key] = table as Extract<T[number], AnyTable<typeof table.tb>>;
-			return acc;
-		},
-		{} as MappedTables<T>,
-	);
+): Orm<T>;
+export function orm<S extends SchemaMap>(
+	surreal: SurrealSession,
+	schema: S,
+): Orm<SchemaMapTables<S>>;
+export function orm(
+	surreal: SurrealSession,
+	...args: AnyTable[] | [SchemaMap]
+): Orm {
+	const tables: AnyTable[] =
+		args.length === 1 && isSchemaMap(args[0])
+			? Object.values(args[0])
+			: (args as AnyTable[]);
+
+	const mapped = tables.reduce<Record<string, AnyTable>>((acc, table) => {
+		acc[table.tb] = table;
+		return acc;
+	}, {});
 
 	const lookup = createLookupFromSchemas(tables);
 
-	return new Orm(surreal, mapped, lookup);
+	return new Orm(surreal, mapped as MappedTables<AnyTable[]>, lookup);
 }

--- a/tests/unit/schema/orm.test.ts
+++ b/tests/unit/schema/orm.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "bun:test";
+import { Surreal } from "surrealdb";
+import { edge, orm, t, table } from "../../../src";
+
+// Compile-time equality assertion helper.
+type Equal<A, B> =
+	(<G>() => G extends A ? 1 : 2) extends <G>() => G extends B ? 1 : 2
+		? true
+		: false;
+
+const user = table("user", {
+	name: t.string(),
+	email: t.string(),
+	age: t.number(),
+});
+const post = table("post", { title: t.string() });
+const authored = edge("user", "authored", "post", { created: t.date() });
+
+describe("orm() schema input forms", () => {
+	test("rest-param form registers tables keyed by table name", () => {
+		const db = orm(new Surreal(), user, post, authored);
+
+		expect(Object.keys(db.tables).sort()).toEqual(["authored", "post", "user"]);
+	});
+
+	test("object form registers the same tables and lookup as rest form", () => {
+		const surreal = new Surreal();
+		const dbRest = orm(surreal, user, post, authored);
+		const dbObj = orm(surreal, { user, post, authored });
+
+		expect(Object.keys(dbObj.tables).sort()).toEqual(
+			Object.keys(dbRest.tables).sort(),
+		);
+		expect(dbObj.tables.user).toBe(dbRest.tables.user);
+		expect(dbObj.lookup).toEqual(dbRest.lookup);
+	});
+
+	test("object form keys by table name, not by the object key", () => {
+		// Deliberately use keys that differ from the table names.
+		const db = orm(new Surreal(), { theUser: user, thePost: post });
+
+		expect(db.tables).toHaveProperty("user");
+		expect(db.tables).toHaveProperty("post");
+		expect(db.tables).not.toHaveProperty("theUser");
+		// Queries still address tables by their `tb` name.
+		expect(db.select("user")).toBeDefined();
+	});
+
+	test("works with a namespace-style object (import * as schema)", () => {
+		const schema = { user, post, authored };
+		const db = orm(new Surreal(), schema);
+
+		expect(Object.keys(db.tables).sort()).toEqual(["authored", "post", "user"]);
+		expect(db.lookup.to.user).toContain("authored");
+	});
+
+	test("empty schema object produces an empty orm", () => {
+		const db = orm(new Surreal(), {});
+
+		expect(db.tables).toEqual({});
+		expect(db.lookup).toEqual({ to: {}, from: {} });
+	});
+});
+
+describe("orm() object form keeps full type support", () => {
+	test("tables and lookup types match the rest-param form exactly", () => {
+		const surreal = new Surreal();
+		const dbRest = orm(surreal, user, post, authored);
+		const dbObj = orm(surreal, { user, post, authored });
+
+		const sameTables: Equal<typeof dbRest.tables, typeof dbObj.tables> = true;
+		const sameLookup: Equal<typeof dbRest.lookup, typeof dbObj.lookup> = true;
+
+		expect(sameTables).toBe(true);
+		expect(sameLookup).toBe(true);
+	});
+
+	test("graph lookup stays precisely typed", () => {
+		const db = orm(new Surreal(), { user, post, authored });
+
+		// Exact tuple types — a wider inference (e.g. `readonly string[]` or
+		// `readonly []`) would fail to type-check here.
+		const toUser: readonly ["authored"] = db.lookup.to.user;
+		const toAuthored: readonly ["post"] = db.lookup.to.authored;
+		const fromPost: readonly ["authored"] = db.lookup.from.post;
+
+		expect(toUser).toEqual(["authored"]);
+		expect(toAuthored).toEqual(["post"]);
+		expect(fromPost).toEqual(["authored"]);
+	});
+
+	test("query building and result inference work through the object form", () => {
+		const db = orm(new Surreal(), { user, post, authored });
+
+		const query = db
+			.select("user")
+			.where((u) => u.age.gte(18))
+			.return((u) => ({ name: u.name, email: u.email }));
+
+		type Result = t.infer<typeof query>;
+		const sample: Result = [{ name: "Alice", email: "alice@example.com" }];
+
+		expect(sample[0]?.name).toBe("Alice");
+	});
+});


### PR DESCRIPTION
Closes #17.

## What

`orm()` now accepts table/edge schemas **either** as individual arguments (the existing form) **or** grouped in a single object. Both are fully supported and produce an identical, fully typed ORM:

```ts
const db = orm(new Surreal(), user, post, authored);   // existing — unchanged
const db = orm(new Surreal(), { user, post, authored }); // new
```

This pairs naturally with a dedicated schema module, the headline use case from #17:

```ts
// database/schema.ts
export const user = table("user", { name: t.string() });
export const post = table("post", { title: t.string() });

// src/db.ts
import * as schema from "../database/schema";
const db = orm(new Surreal(), schema);
```

## Why

Improves DX for defining schemas in one place and reusing them across multiple `orm` instances, without forcing the rest-param spread. The existing rest-param API is fully preserved.

## How it works

- **Overloaded `orm()`** with a second typed signature. The form is detected at runtime by whether the second argument is a `TableSchema`/`EdgeSchema` instance or a plain object (`isSchemaMap`). The object form is `Object.values(...)`'d back into the same internal array the rest form already used, so all downstream behavior (queries, graph lookup, transactions) is identical.
- **Tables stay keyed by their `tb` name**, not the object key — so `db.select("user")` works regardless of form, and `import * as schema` works even when export names differ from table names. The object keys are purely organizational.
- **Full type parity**: the value union is converted to a tuple (`SchemaMapTables`) so the object form resolves to the exact same `Orm<[...]>` type as the rest form, preserving precise graph-lookup types and query inference. The lookup machinery is intentionally left untouched (an earlier union-based approach regressed the loose `Orm<AnyTable[]>` default and broke `WorkableContext` variance across the API).

## Tests

New `tests/unit/schema/orm.test.ts` covering:
- runtime equivalence between the two forms (same `tables`, same `lookup`)
- object key vs. table name semantics, namespace-style objects, and the empty-object case
- **compile-time** assertions that the object form keeps full type support (precise graph lookup tuples, query result inference) — verified to fail compilation if the types regress

All checks pass locally: `bun run type-check`, `biome check .` (134 files), and `bun test tests/unit/` (490 pass / 0 fail). Integration tests require a live SurrealDB and were not run locally, but are unaffected — the test helper uses the rest form, which routes through the unchanged internal path.

## Reviewer note

With `import * as schema`, the type constraint requires every export to be a table/edge — a stray non-schema export would be a type error. This matches the dedicated-schema-file intent of #17; happy to relax it to silently ignore non-schema values at runtime if preferred.