### PR TITLE
Fix `.then.val()` / `.then.at()` to resolve query results (#21)

### DIFF
--- a/src/query/abstract.ts
+++ b/src/query/abstract.ts
@@ -5,11 +5,9 @@ import {
 	__type,
 	type DisplayContext,
 	displayContext,
-	sanitizeWorkable,
 	type Workable,
 	type WorkableContext,
 } from "../utils";
-import { type Actionable, actionable } from "../utils/actionable";
 
 /**
  * Abstract base class for all query types. Implements `Workable` so queries can
@@ -80,7 +78,7 @@ export abstract class Query<
 	}
 
 	// biome-ignore lint/suspicious/noThenProperty: entire point of the class
-	get then(): Then<this> & Actionable<C, T> {
+	get then(): Then<this> & ThenAccessors<this> {
 		const fn = <TResult1 = this["type"], TResult2 = never>(
 			onFulfilled?:
 				| ((value: this["type"]) => TResult1 | PromiseLike<TResult1>)
@@ -94,9 +92,28 @@ export abstract class Query<
 			return this.execute().then(onFulfilled, onRejected);
 		};
 
-		const workable = sanitizeWorkable(this);
-		const functions = actionable(workable);
-		return Object.assign(fn, functions) as Then<this> & Actionable<C, T>;
+		// Convenience accessors that execute the query and index into the
+		// resolved result array client-side. All queries return arrays, so these
+		// extract a single record. See README "Accessing Single Records".
+		const val = (): Promise<ResultElement<this["type"]> | undefined> =>
+			this.execute().then(
+				(result) =>
+					(Array.isArray(result) ? result.at(0) : result) as
+						| ResultElement<this["type"]>
+						| undefined,
+			);
+
+		const at = (
+			index: number,
+		): Promise<ResultElement<this["type"]> | undefined> =>
+			this.execute().then(
+				(result) =>
+					(Array.isArray(result) ? result.at(index) : undefined) as
+						| ResultElement<this["type"]>
+						| undefined,
+			);
+
+		return Object.assign(fn, { val, at }) as Then<this> & ThenAccessors<this>;
 	}
 
 	/** Execute the query against SurrealDB and return the parsed result. */
@@ -123,3 +140,20 @@ type Then<Q extends Query> = <TResult1 = Q["type"], TResult2 = never>(
 		| undefined
 		| null,
 ) => Promise<TResult1 | TResult2>;
+
+/** The element type of an array result, or the result itself if not an array. */
+type ResultElement<T> = T extends readonly (infer E)[] ? E : T;
+
+/**
+ * Convenience accessors hung off {@link Query.then} for reaching into a query's
+ * result array without first awaiting it into a variable.
+ */
+type ThenAccessors<Q extends Query> = {
+	/** Execute the query and resolve to the first result, or `undefined`. */
+	val(): Promise<ResultElement<Q["type"]> | undefined>;
+	/**
+	 * Execute the query and resolve to the result at `index`, or `undefined`.
+	 * Negative indexes count from the end (e.g. `-1` is the last result).
+	 */
+	at(index: number): Promise<ResultElement<Q["type"]> | undefined>;
+};

--- a/tests/unit/query/then-accessors.test.ts
+++ b/tests/unit/query/then-accessors.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+import { RecordId, type SurrealSession } from "surrealdb";
+import { orm, t, table } from "../../../src";
+
+const user = table("user", {
+	name: t.string(),
+	age: t.number(),
+});
+
+const alice = { id: new RecordId("user", "alice"), name: "alice", age: 30 };
+const bob = { id: new RecordId("user", "bob"), name: "bob", age: 25 };
+const carol = { id: new RecordId("user", "carol"), name: "carol", age: 40 };
+const rows = [alice, bob, carol];
+
+/** Build an ORM whose SurrealDB session returns `result` for every query. */
+function mockDb(result: unknown[]) {
+	const surreal = {
+		query: async () => [result],
+	} as unknown as SurrealSession;
+	return orm(surreal, user);
+}
+
+describe("Query.then result accessors", () => {
+	test("then.val() resolves to the first record", async () => {
+		const db = mockDb(rows);
+		expect(await db.select("user").then.val()).toEqual(alice);
+	});
+
+	test("then.val() resolves to undefined for empty results", async () => {
+		const db = mockDb([]);
+		expect(await db.select("user").then.val()).toBeUndefined();
+	});
+
+	test("then.at(index) resolves to the record at that index", async () => {
+		const db = mockDb(rows);
+		expect(await db.select("user").then.at(0)).toEqual(alice);
+		expect(await db.select("user").then.at(1)).toEqual(bob);
+	});
+
+	test("then.at supports negative indexing", async () => {
+		const db = mockDb(rows);
+		expect(await db.select("user").then.at(-1)).toEqual(carol);
+	});
+
+	test("then.at out of range resolves to undefined", async () => {
+		const db = mockDb(rows);
+		expect(await db.select("user").then.at(99)).toBeUndefined();
+	});
+
+	test("query still resolves to the full array when awaited directly", async () => {
+		const db = mockDb(rows);
+		const all = await db.select("user");
+		expect(all).toHaveLength(3);
+		expect(all).toEqual(rows);
+	});
+
+	// Regression for https://github.com/surrealdb/surqlize/issues/21:
+	// .then.val()/.then.at() used to return an Actionable query-expression
+	// (carrying helpers like eq/contains) instead of executing the query and
+	// resolving to a record.
+	test("then.val() returns a Promise, not an Actionable expression", async () => {
+		const db = mockDb(rows);
+		const result = db.select("user").then.val();
+		expect(result).toBeInstanceOf(Promise);
+		await result;
+	});
+
+	test("resolved record carries no query-expression helpers", async () => {
+		const db = mockDb(rows);
+		const first = (await db.select("user").then.val()) as Record<
+			string,
+			unknown
+		>;
+		expect(typeof first.eq).not.toBe("function");
+		expect(typeof first.contains).not.toBe("function");
+		expect(typeof first.val).not.toBe("function");
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #21. `.then.val()` and `.then.at(index)` returned an **Actionable query-expression** (an object carrying helpers like `eq`/`contains`/`val`) instead of executing the query and returning a record — so `await db.select("user").then.val()` resolved to that Actionable object rather than the first row, contradicting the README's documented behavior.

## Root cause

The `Query.then` getter merged the server-side query-expression actionable onto the promise function:

```ts
const workable = sanitizeWorkable(this);
const functions = actionable(workable);
return Object.assign(fn, functions) as Then<this> & Actionable<C, T>;
```

`actionable()`'s `val`/`at` are the SurrealQL `array::at(...)` **expression builders** (bound to the query workable in `getFunctions`), not client-side result accessors. The returned Actionable isn't thenable, so `await` handed it straight back. (It couldn't even render — `sanitizeWorkable` strips the `Query` methods that `SelectQuery[__display]` depends on.) The path had zero test coverage, so it shipped broken.

## Fix

Replace the actionable merge with client-side accessors that execute the query and index into the resolved array:

```ts
const val = () => this.execute().then((r) => (Array.isArray(r) ? r.at(0) : r));
const at  = (index) => this.execute().then((r) => (Array.isArray(r) ? r.at(index) : undefined));
return Object.assign(fn, { val, at });
```

- `.then.val()` → first record (or `undefined`); `.then.at(index)` → record at `index` (or `undefined`), with negative indexing via `Array.prototype.at`.
- Return type narrowed to `Then<this> & ThenAccessors<this>`, so `.then.val()` is correctly typed `Promise<User | undefined>`.
- Dropped the now-unused `actionable` / `sanitizeWorkable` / `Actionable` imports.
- Awaiting a query directly (`await db.select(...)`) is unchanged.

The README and `examples/demo.ts` already described the correct behavior, so they needed no changes — the code was the bug.

## Tests

New `tests/unit/query/then-accessors.test.ts` (8 tests, mocked SurrealDB session — no live DB needed) exercises the real `execute → parse → index` path: first record, empty→undefined, positional `.at()`, negative indexing, out-of-range→undefined, direct-array await still works, plus regression guards that the accessors return a `Promise` and the resolved record carries no expression helpers.

- `tsc --noEmit`: clean
- `bun test tests/unit/`: 490 pass, 0 fail (incl. the 8 new)
- `biome check`: clean