### PR TITLE
fix: apply nested type conversions in parse()

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -6,7 +6,8 @@
 		"useIgnoreFile": true
 	},
 	"files": {
-		"ignoreUnknown": false
+		"ignoreUnknown": false,
+		"includes": ["**", "!**/.claude"]
 	},
 	"formatter": {
 		"enabled": true,

--- a/src/types/classes.ts
+++ b/src/types/classes.ts
@@ -185,6 +185,18 @@ export class OptionType<T extends AbstractType> extends AbstractType<
 	validate(value: unknown): value is this["infer"] {
 		return value === undefined || this.schema.validate(value);
 	}
+
+	/**
+	 * Parse `value` against the inner schema, returning `undefined` when the
+	 * value is absent. Delegates to the inner type so conversions (e.g. dates)
+	 * are applied.
+	 *
+	 * @throws {TypeParseError} If `value` is defined but fails the inner schema.
+	 */
+	parse(value: unknown): this["infer"] {
+		if (value === undefined) return undefined;
+		return this.schema.parse(value);
+	}
 }
 
 export class RecordType<
@@ -246,18 +258,21 @@ export class ObjectType<
 	}
 
 	/**
-	 * Validate every field of `value` against the object schema.
+	 * Validate every field of `value` against the object schema, returning a new
+	 * object whose schema fields hold the parsed (and possibly converted) values.
 	 *
 	 * @throws {TypeParseError} If `value` is not an object or a field fails validation.
 	 */
 	parse(value: unknown): this["infer"] {
 		if (typeof value !== "object" || value === null)
 			throw new TypeParseError(this.name, this.expected, value);
+		const source = value as Record<string, unknown>;
+		const result: Record<string, unknown> = { ...source };
 		for (const key in this.schema) {
-			this.schema[key]!.parse((value as this["infer"])[key]);
+			result[key] = this.schema[key]!.parse(source[key]);
 		}
 
-		return value as this["infer"];
+		return result as this["infer"];
 	}
 
 	get(prop: string | number): [AbstractType, string] {
@@ -315,7 +330,8 @@ export class ArrayType<
 	}
 
 	/**
-	 * Validate every element of `value` against the array or tuple schema.
+	 * Validate every element of `value` against the array or tuple schema,
+	 * returning a new array of the parsed (and possibly converted) elements.
 	 *
 	 * @throws {TypeParseError} If `value` is not an array, has the wrong length
 	 *   (tuple), or an element fails validation.
@@ -323,18 +339,13 @@ export class ArrayType<
 	parse(value: unknown): this["infer"] {
 		if (!Array.isArray(value))
 			throw new TypeParseError(this.name, this.expected, value);
-		if (Array.isArray(this.schema)) {
-			if (this.schema.length !== value.length)
+		const schema = this.schema;
+		if (Array.isArray(schema)) {
+			if (schema.length !== value.length)
 				throw new TypeParseError(this.name, this.expected, value);
-			for (let i = 0; i < this.schema.length; i++) {
-				this.schema[i]!.parse(value[i]);
-			}
-		} else {
-			for (const item of value) {
-				this.schema.parse(item);
-			}
+			return schema.map((item, i) => item.parse(value[i])) as this["infer"];
 		}
-		return value as this["infer"];
+		return value.map((item) => schema.parse(item)) as this["infer"];
 	}
 
 	get(prop: number): [AbstractType, string] {
@@ -386,5 +397,18 @@ export class UnionType<T extends AbstractType[]> extends AbstractType<
 			if (schema.validate(value)) return true;
 		}
 		return false;
+	}
+
+	/**
+	 * Parse `value` against the first matching member, delegating so that member
+	 * conversions (e.g. dates) are applied.
+	 *
+	 * @throws {TypeParseError} If `value` matches none of the members.
+	 */
+	parse(value: unknown): this["infer"] {
+		for (const schema of this.schema) {
+			if (schema.validate(value)) return schema.parse(value) as this["infer"];
+		}
+		throw new TypeParseError(this.name, this.expected, value);
 	}
 }

--- a/tests/integration/return-projections.test.ts
+++ b/tests/integration/return-projections.test.ts
@@ -277,6 +277,67 @@ describe("Return projection integration tests", () => {
 				expect(row.when).toBeDefined();
 			}
 		});
+
+		// ─── Date conversion ─────────────────────────────────────────────────
+
+		test("RETURN VALUE <field> — single date field is a JS Date", async () => {
+			const { db } = getTestDb();
+			const result = await db
+				.select("user")
+				.return((r) => r.created)
+				.execute();
+
+			expect(result.length).toBe(3);
+			for (const created of result) {
+				expect(created).toBeInstanceOf(Date);
+			}
+		});
+
+		test("RETURN { ... } — date nested in object is a JS Date", async () => {
+			const { db } = getTestDb();
+			const result = await db
+				.select("user")
+				.return((p) => ({ when: p.created }))
+				.execute();
+
+			expect(result.length).toBe(3);
+			for (const row of result) {
+				expect(row.when).toBeInstanceOf(Date);
+			}
+		});
+
+		test("RETURN [ ... ] — date nested in array is a JS Date", async () => {
+			const { db } = getTestDb();
+			const result = await db
+				.select("user")
+				.return((p) => [p.email, p.created])
+				.execute();
+
+			expect(result.length).toBe(3);
+			for (const row of result) {
+				expect(typeof row[0]).toBe("string");
+				expect(row[1]).toBeInstanceOf(Date);
+			}
+		});
+
+		test("RETURN { ... } — dates deeply nested in object and array", async () => {
+			const { db } = getTestDb();
+			const result = await db
+				.select("user")
+				.return((p) => ({
+					meta: { timestamps: [p.created, p.updated] },
+				}))
+				.execute();
+
+			expect(result.length).toBe(3);
+			for (const row of result) {
+				expect(Array.isArray(row.meta.timestamps)).toBe(true);
+				expect(row.meta.timestamps.length).toBe(2);
+				for (const ts of row.meta.timestamps) {
+					expect(ts).toBeInstanceOf(Date);
+				}
+			}
+		});
 	});
 
 	// ─── CREATE ────────────────────────────────────────────────────────────

--- a/tests/unit/types/t.test.ts
+++ b/tests/unit/types/t.test.ts
@@ -270,10 +270,27 @@ describe("Type builders", () => {
 			expect(() => t.bool().parse(1)).toThrow(TypeParseError);
 		});
 
-		test("ObjectType.parse() returns valid object", () => {
+		test("ObjectType.parse() returns parsed object", () => {
 			const type = t.object({ name: t.string() });
 			const val = { name: "Alice" };
-			expect(type.parse(val)).toBe(val);
+			expect(type.parse(val)).toEqual(val);
+		});
+
+		test("ObjectType.parse() converts nested dates", () => {
+			const type = t.object({ when: t.date() });
+			const fakeDateTime = { toDate: () => new Date("2024-01-01") };
+			const result = type.parse({ when: fakeDateTime });
+			expect(result.when).toBeInstanceOf(Date);
+			expect(result.when.getFullYear()).toBe(2024);
+		});
+
+		test("ObjectType.parse() preserves keys outside the schema", () => {
+			const type = t.object({ name: t.string() });
+			const result = type.parse({ name: "Alice", extra: 42 }) as Record<
+				string,
+				unknown
+			>;
+			expect(result.extra).toBe(42);
 		});
 
 		test("ObjectType.parse() throws for null", () => {
@@ -288,10 +305,28 @@ describe("Type builders", () => {
 			);
 		});
 
-		test("ArrayType.parse() returns valid array", () => {
+		test("ArrayType.parse() returns parsed array", () => {
 			const type = t.array(t.string());
 			const val = ["a", "b"];
-			expect(type.parse(val)).toBe(val);
+			expect(type.parse(val)).toEqual(val);
+		});
+
+		test("ArrayType.parse() converts dates in a homogeneous array", () => {
+			const type = t.array(t.date());
+			const fakeDateTime = { toDate: () => new Date("2024-01-01") };
+			const result = type.parse([fakeDateTime, fakeDateTime]);
+			expect(result.length).toBe(2);
+			for (const item of result) {
+				expect(item).toBeInstanceOf(Date);
+			}
+		});
+
+		test("ArrayType.parse() converts dates in a tuple", () => {
+			const type = t.array([t.string(), t.date()]);
+			const fakeDateTime = { toDate: () => new Date("2024-01-01") };
+			const result = type.parse(["a", fakeDateTime]);
+			expect(result[0]).toBe("a");
+			expect(result[1]).toBeInstanceOf(Date);
 		});
 
 		test("ArrayType.parse() throws for non-array", () => {
@@ -321,6 +356,31 @@ describe("Type builders", () => {
 
 		test("DateType.parse() throws for invalid value", () => {
 			expect(() => t.date().parse("2024-01-01")).toThrow(TypeParseError);
+		});
+
+		test("OptionType.parse() returns undefined for absent value", () => {
+			expect(t.option(t.date()).parse(undefined)).toBeUndefined();
+		});
+
+		test("OptionType.parse() converts the inner value", () => {
+			const fakeDateTime = { toDate: () => new Date("2024-01-01") };
+			expect(t.option(t.date()).parse(fakeDateTime)).toBeInstanceOf(Date);
+		});
+
+		test("OptionType.parse() throws for a defined invalid value", () => {
+			expect(() => t.option(t.date()).parse("nope")).toThrow(TypeParseError);
+		});
+
+		test("UnionType.parse() converts via the matching member", () => {
+			const type = t.union([t.string(), t.date()]);
+			const fakeDateTime = { toDate: () => new Date("2024-01-01") };
+			expect(type.parse(fakeDateTime)).toBeInstanceOf(Date);
+			expect(type.parse("hello")).toBe("hello");
+		});
+
+		test("UnionType.parse() throws when no member matches", () => {
+			const type = t.union([t.string(), t.number()]);
+			expect(() => type.parse(true)).toThrow(TypeParseError);
 		});
 	});
 


### PR DESCRIPTION
## Problem

`ObjectType.parse` and `ArrayType.parse` called each child type's `parse()` but **discarded the return value** and returned the original raw `value`. So value-*transforming* types only took effect at the top level.

The concrete symptom: `DateType.parse` converts a SurrealDB datetime wrapper into a JS `Date` (via `.toDate()`). That worked for a top-level single-field projection (`.return(r => r.created)`), but for a date nested in an object/array projection:

```ts
.return(p => ({ when: p.created }))
```

the converted `Date` was thrown away and the caller got back the raw SurrealDB datetime instead.

`UnionType` and `OptionType` had **no `parse()` override** at all, so they inherited the base validate-then-return-as-is behavior and likewise never applied their inner type's conversion (e.g. `t.option(t.date())`, or a `t.date()` member of a union).

## Fix — `src/types/classes.ts`

- **`ObjectType.parse`** rebuilds the object, assigning each schema field its parsed value. Keys outside the schema are preserved (spread first), so schemaless extras still pass through unchanged — only the behavior for transforming types changes.
- **`ArrayType.parse`** maps tuple/array elements through the child `parse()`.
- **`OptionType.parse`** (new) delegates to the inner schema; `undefined` passes through.
- **`UnionType.parse`** (new) delegates to the first matching member, throwing `TypeParseError` if none match.

## Tests

- `tests/unit/types/t.test.ts`: two existing tests asserted reference identity (`toBe`) on `parse` — that contract is intentionally gone, so they now assert structural equality, plus new coverage for nested/tuple/optional/union date conversion and for preserving extra object keys.
- `tests/integration/return-projections.test.ts`: added date-projection cases — the exact `({ when: p.created })` repro, date-in-array, and a deeply-nested date inside an object+array.

## Reviewer notes

- This branch was rebased onto current `main`; it composes cleanly with the recent `get()` dot-notation refactor (#23) — those changes touch different methods.
- `biome.json` gains `"includes": ["**", "!**/.claude"]` so `bun run qc` ignores Claude Code worktree copies under `.claude/`. Biome's `useIgnoreFile` only reads project-level `.gitignore`/`.ignore`, not git's global excludesfile, so the exclusion has to live in the Biome config. Happy to drop this hunk if you'd rather handle it separately.

## Verification

- `bun run type-check` — clean
- `bun run qc` — clean (137 files)
- `SURREAL_URL=ws://localhost:8000 bun test` — 633 pass, 1 skip, 0 fail