### PR TITLE
Support SurrealDB live queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ A type-safe TypeScript ORM for SurrealDB that provides full type inference, a fl
 - **Automatic type inference** - Get full TypeScript types without code generation
 - **Fluent query builder** - Chain `.select()`, `.where()`, `.return()` with full type safety
 - **Complete CRUD operations** - SELECT, CREATE, UPDATE, DELETE, and UPSERT queries
+- **Live queries** - Real-time `LIVE SELECT` subscriptions with typed notifications
 - **Graph relationships** - First-class support for edges and graph traversal
 - **Rich type system** - Objects, arrays, unions, literals, options, and more
 - **SurrealDB functions** - Integrated string, array, and record operations
@@ -707,6 +708,93 @@ try {
 
 The transaction object (`tx`) has all the same query-builder methods as the main `db` instance — `select`, `create`, `insert`, `update`, `upsert`, `delete`, and `relate`.
 
+## Live queries
+
+Subscribe to real-time changes with `db.live()`. It compiles to a SurrealDB [`LIVE SELECT`](https://surrealdb.com/docs/surrealql/statements/live) statement and resolves to a typed `LiveSubscription`:
+
+```typescript
+// Open a subscription to every change on the `user` table
+const sub = await db.live("user");
+
+// Handle notifications (returns a function that unsubscribes this handler)
+const off = sub.subscribe((msg) => {
+  // msg.action:   "CREATE" | "UPDATE" | "DELETE" | "KILLED"
+  // msg.recordId: the affected RecordId
+  // msg.value:    the affected record, parsed against the schema
+  console.log(msg.action, msg.value);
+});
+
+// Stop receiving updates on this handler...
+off();
+// ...or kill the subscription entirely
+await sub.kill();
+```
+
+The notification `value` is parsed against the table schema, so it is fully typed:
+
+```typescript
+const sub = await db.live("user");
+sub.subscribe((msg) => {
+  msg.value.name.first; // string
+  msg.value.age; // number
+});
+```
+
+A subscription is also async-iterable:
+
+```typescript
+for await (const msg of await db.live("user")) {
+  console.log(msg.action, msg.value);
+}
+```
+
+### Filtering, projecting and fetching
+
+Live queries support `.where()`, `.return()` (a `VALUE` projection) and `.fetch()`, mirroring `select`:
+
+```typescript
+// Only notify for adult users
+const adults = await db.live("user").where((user) => user.age.gte(18));
+
+// Project a subset of fields
+const names = await db.live("user").return((user) => ({
+  name: user.name,
+  email: user.email,
+}));
+
+// Resolve record links in notifications
+const posts = await db.live("post").fetch("author");
+```
+
+> **Note:** Filtering or projecting a live query relies on query parameters, which require **SurrealDB ≥ 3.0** (`FETCH` requires ≥ 2.2.0). On older servers a parameterized live query is accepted but never delivers notifications.
+
+### Diffs
+
+Use `.diff()` to receive [JSON Patch](https://jsonpatch.com) arrays instead of full records (`LIVE SELECT DIFF`):
+
+```typescript
+const sub = await db.live("user").diff();
+sub.subscribe((msg) => {
+  // msg.value is a JsonPatchOp[]
+});
+```
+
+### Subscribe in one step
+
+Calling `.subscribe(handler)` on the builder starts the query and returns a stop function that both unsubscribes and kills the subscription:
+
+```typescript
+const stop = await db
+  .live("user")
+  .where((user) => user.age.gte(18))
+  .subscribe((msg) => console.log(msg.action, msg.value));
+
+// later
+stop();
+```
+
+> Live subscriptions are **unmanaged** — they are not automatically restarted if the connection drops and reconnects. The table must also exist before subscribing (define it up front, e.g. with `DEFINE TABLE`).
+
 ## Accessing Single Records
 
 All queries in Surqlize return arrays, even when selecting by a specific record ID. To access the first item from a query result, use `.val()` or `.at(index)`:
@@ -1282,6 +1370,7 @@ This project is in active development. Planned features include:
 - [x] **Advanced query clauses** - ORDER BY, GROUP BY, FETCH, SPLIT
 - [x] **Transaction support** - Batch and interactive transactions
 - [x] **Multi-session support** - Multiple sessions over a single connection
+- [x] **Live queries** - Real-time `LIVE SELECT` subscriptions with typed notifications
 - [ ] **Runtime validation** - Validate data at runtime using schema definitions
 - [ ] **Advanced graph traversal** - Path finding, recursive queries, graph algorithms
 - [ ] **Performance optimizations** - Query caching, connection pooling

--- a/examples/demo.ts
+++ b/examples/demo.ts
@@ -316,6 +316,16 @@ const complexSelect = db
 	.fetch("metadata")
 	.timeout("10s");
 
+// LIVE SELECT
+const liveUsers = db.live("user");
+const liveAdults = db.live("user").where(($this) => $this.age.gte(18));
+const liveDiff = db.live("user").diff();
+const liveProjected = db.live("user").return((user) => ({
+	name: user.name,
+	email: user.email,
+}));
+const liveFetch = db.live("post").fetch("author");
+
 // Display generated queries
 console.log("\n=== SELECT: ORDER BY ===");
 console.log(orderByAge[__display](displayContext()));
@@ -337,6 +347,16 @@ console.log("\n=== SELECT: TIMEOUT ===");
 console.log(timedQuery[__display](displayContext()));
 console.log("\n=== SELECT: COMBINED ===");
 console.log(complexSelect[__display](displayContext()));
+console.log("\n=== LIVE SELECT ===");
+console.log(liveUsers[__display](displayContext()));
+console.log("\n=== LIVE SELECT: WHERE ===");
+console.log(liveAdults[__display](displayContext()));
+console.log("\n=== LIVE SELECT: DIFF ===");
+console.log(liveDiff[__display](displayContext()));
+console.log("\n=== LIVE SELECT: VALUE projection ===");
+console.log(liveProjected[__display](displayContext()));
+console.log("\n=== LIVE SELECT: FETCH ===");
+console.log(liveFetch[__display](displayContext()));
 
 console.log("\n=== CREATE ===");
 console.log(createUser[__display](displayContext()));

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export * from "./query/batch";
 export * from "./query/create";
 export * from "./query/delete";
 export * from "./query/insert";
+export * from "./query/live";
 export * from "./query/relate";
 export * from "./query/select";
 export * from "./query/transaction";

--- a/src/query/live.ts
+++ b/src/query/live.ts
@@ -1,0 +1,334 @@
+import {
+	type LiveAction,
+	type RecordId,
+	type SurrealSession,
+	Table,
+	type Uuid,
+} from "surrealdb";
+import type { Orm } from "../schema/orm.ts";
+import { type AbstractType, ObjectType, type RecordType } from "../types";
+import { type Actionable, actionable } from "../utils/actionable.ts";
+import { type DisplayContext, displayContext } from "../utils/display.ts";
+import {
+	type Inheritable,
+	type InheritableIntoType,
+	inheritableIntoWorkable,
+} from "../utils/inheritable.ts";
+import {
+	__ctx,
+	__display,
+	__type,
+	isWorkable,
+	sanitizeWorkable,
+	type Workable,
+	type WorkableContext,
+} from "../utils/workable.ts";
+import type { JsonPatchOp } from "./modification-methods.ts";
+import {
+	type FetchedSchema,
+	type FetchPaths,
+	resolveFetchObject,
+} from "./select.ts";
+
+/** The underlying SDK subscription returned by `surreal.liveOf()`. */
+type SdkLiveSubscription = Awaited<ReturnType<SurrealSession["liveOf"]>>;
+
+/**
+ * A single live-query notification: the change `action`, the affected
+ * `recordId`, and the `value` (the affected record, parsed against the query's
+ * schema — or a JSON Patch array when the query was created with `.diff()`).
+ *
+ * For `KILLED` notifications the `value` carries no record payload.
+ */
+export type LiveMessage<T> = {
+	action: LiveAction;
+	recordId: RecordId;
+	value: T;
+};
+
+/**
+ * A typed wrapper around a SurrealDB live subscription. Obtain one by awaiting a
+ * {@link LiveQuery} (e.g. `const sub = await db.live("user")`).
+ *
+ * Notification values are mapped through the query's schema so handlers and
+ * iteration receive fully-typed records.
+ */
+export class LiveSubscription<T> {
+	constructor(
+		private readonly inner: SdkLiveSubscription,
+		private readonly mapValue: (raw: unknown, action: LiveAction) => T,
+	) {}
+
+	/** The id of the underlying live subscription. */
+	get id(): Uuid {
+		return this.inner.id;
+	}
+
+	/**
+	 * Subscribe to notifications. Returns a function that unsubscribes this
+	 * handler (it does not kill the subscription — use {@link kill} for that).
+	 */
+	subscribe(handler: (message: LiveMessage<T>) => void): () => void {
+		return this.inner.subscribe((message) =>
+			handler({
+				action: message.action,
+				recordId: message.recordId,
+				value: this.mapValue(message.value, message.action),
+			}),
+		);
+	}
+
+	/** Async-iterate notifications: `for await (const msg of sub) { … }`. */
+	async *[Symbol.asyncIterator](): AsyncIterator<LiveMessage<T>> {
+		for await (const message of this.inner) {
+			yield {
+				action: message.action,
+				recordId: message.recordId,
+				value: this.mapValue(message.value, message.action),
+			};
+		}
+	}
+
+	/** Kill the live subscription and stop receiving updates. */
+	kill(): Promise<void> {
+		return this.inner.kill();
+	}
+}
+
+/**
+ * A fluent `LIVE SELECT` query builder. Supports `WHERE`, `FETCH`, return
+ * projections via `.return()`, and `.diff()`.
+ *
+ * Awaiting the builder runs the `LIVE SELECT` and resolves to a typed
+ * {@link LiveSubscription}; alternatively call `.subscribe(handler)` to start
+ * it and receive a stop function in one step.
+ *
+ * @remarks
+ * `LIVE SELECT` does not support `ORDER BY` / `LIMIT` / `START` / `GROUP` /
+ * `SPLIT`. Filtering or projecting (`.where()`, `.return()`, `.fetch()`) relies
+ * on query parameters, which require **SurrealDB ≥ 3.0**; on older servers a
+ * parameterized live query is accepted but never delivers notifications.
+ * Subscriptions are unmanaged and are not automatically restarted on reconnect.
+ *
+ * @typeParam E - The per-record entry type.
+ * @typeParam V - The notification value type (defaults to `E["infer"]`; becomes
+ *   `JsonPatchOp[]` after `.diff()`).
+ */
+export class LiveQuery<
+	O extends Orm,
+	C extends WorkableContext<O>,
+	T extends keyof O["tables"] & string,
+	E extends AbstractType = O["tables"][T]["schema"],
+	V = E["infer"],
+> {
+	readonly [__ctx]: C;
+	private _filter?: Workable<C>;
+	private _entry?: Workable<C, E>;
+	private _fetch?: string[];
+	private _fetchResolvedType?: AbstractType;
+	private _diff = false;
+	private tb: T;
+	private subject: T | RecordId<T> | Workable<C, RecordType<T>>;
+
+	constructor(orm: O, subject: T | RecordId<T> | Workable<C, RecordType<T>>) {
+		this[__ctx] = {
+			orm,
+			id: Symbol(),
+		} as C;
+
+		this.subject = subject;
+
+		if (typeof subject === "string") {
+			this.tb = subject;
+		} else if (isWorkable(subject)) {
+			this.tb = subject[__type].tb;
+		} else {
+			this.tb = String(subject.table) as T;
+		}
+	}
+
+	get entry(): E {
+		// Mirrors SelectQuery.entry: a return projection defines the result shape
+		// and takes precedence over the fetch-resolved schema.
+		return (this._entry?.[__type] ??
+			this._fetchResolvedType ??
+			this[__ctx].orm.tables[this.tb]!.schema) as E;
+	}
+
+	get [__type](): E {
+		return this.entry;
+	}
+
+	return<
+		P extends Inheritable<C>,
+		R extends InheritableIntoType<C, P> = InheritableIntoType<C, P>,
+	>(cb: (tb: Actionable<C, E>) => P): LiveQuery<O, C, T, R, R["infer"]> {
+		const tb = actionable({
+			[__ctx]: this[__ctx],
+			[__type]: this.entry,
+			[__display]: ({ contextId }) => {
+				return contextId === this[__ctx].id ? "$this" : "$parent";
+			},
+		}) as Actionable<C, E>;
+
+		const predicable = cb(tb);
+		const workable = inheritableIntoWorkable<C, P>(
+			predicable,
+		) as unknown as Workable<C, R>;
+		const entry = sanitizeWorkable(workable);
+
+		(this as unknown as LiveQuery<O, C, T, R, R["infer"]>)._entry = entry;
+		return this as unknown as LiveQuery<O, C, T, R, R["infer"]>;
+	}
+
+	where(
+		cb: (tb: Actionable<C, O["tables"][T]["schema"]>) => Workable<C>,
+	): this {
+		const tb = actionable({
+			[__ctx]: this[__ctx],
+			[__type]: this[__ctx].orm.tables[this.tb]!.schema,
+			[__display]: ({ contextId }) => {
+				return contextId === this[__ctx].id ? "$this" : "$parent";
+			},
+		}) as Actionable<C, O["tables"][T]["schema"]>;
+
+		this._filter = sanitizeWorkable(cb(tb));
+		return this;
+	}
+
+	fetch<P extends FetchPaths<O, T>>(
+		...fields: P[]
+	): LiveQuery<
+		O,
+		C,
+		T,
+		FetchedSchema<O, E, P>,
+		FetchedSchema<O, E, P>["infer"]
+	> {
+		this._fetch = fields;
+
+		// Reuse SelectQuery's resolved-schema logic so notification values are
+		// validated as the resolved records instead of expecting RecordIds.
+		const currentSchema =
+			this._entry?.[__type] ?? this[__ctx].orm.tables[this.tb]!.schema;
+		if (currentSchema instanceof ObjectType) {
+			this._fetchResolvedType = resolveFetchObject(
+				currentSchema,
+				fields,
+				this[__ctx].orm,
+			);
+		}
+
+		return this as unknown as LiveQuery<
+			O,
+			C,
+			T,
+			FetchedSchema<O, E, P>,
+			FetchedSchema<O, E, P>["infer"]
+		>;
+	}
+
+	/**
+	 * Receive updates as JSON Patch arrays (`LIVE SELECT DIFF`) instead of full
+	 * records. Mutually exclusive with a `.return()` projection.
+	 */
+	diff(): LiveQuery<O, C, T, E, JsonPatchOp[]> {
+		this._diff = true;
+		return this as unknown as LiveQuery<O, C, T, E, JsonPatchOp[]>;
+	}
+
+	private displaySubject(ctx: DisplayContext): string {
+		if (typeof this.subject === "string") return ctx.var(new Table(this.tb));
+		if (isWorkable(this.subject)) return this.subject[__display](ctx);
+		return ctx.var(this.subject);
+	}
+
+	[__display](inp: DisplayContext): string {
+		const ctx = displayContext({
+			...inp,
+			contextId: this[__ctx].id,
+		});
+
+		const thing = this.displaySubject(ctx);
+
+		const projection = this._diff
+			? "DIFF"
+			: this._entry
+				? /* surql */ `VALUE ${this._entry[__display](ctx)}`
+				: "*";
+
+		let query = /* surql */ `LIVE SELECT ${projection} FROM ${thing}`;
+
+		if (this._filter)
+			query += /* surql */ ` WHERE ${this._filter[__display](ctx)}`;
+
+		if (this._fetch && this._fetch.length > 0)
+			query += /* surql */ ` FETCH ${this._fetch.join(", ")}`;
+
+		return query;
+	}
+
+	/** Render the query as a SurrealQL string. */
+	toString(): string {
+		const ctx = displayContext();
+		return this[__display](ctx);
+	}
+
+	/** Start the live query and resolve to a typed {@link LiveSubscription}. */
+	async execute(): Promise<LiveSubscription<V>> {
+		const ctx = displayContext();
+		const query = this[__display](ctx);
+		const { surreal } = this[__ctx].orm;
+
+		const [uuid] = await surreal.query<[Uuid]>(query, ctx.variables);
+		const inner = await surreal.liveOf(uuid);
+
+		const type = this.entry;
+		const diff = this._diff;
+		const mapValue = (raw: unknown, action: LiveAction): V => {
+			// DIFF yields JSON Patch arrays, and KILLED carries no record payload —
+			// pass those through unparsed.
+			if (diff || action === "KILLED") return raw as V;
+			return type.parse(raw) as V;
+		};
+
+		return new LiveSubscription<V>(inner, mapValue);
+	}
+
+	/**
+	 * Start the live query and subscribe `handler` in one step. Returns a stop
+	 * function that unsubscribes the handler and kills the subscription.
+	 */
+	subscribe(handler: (message: LiveMessage<V>) => void): Promise<() => void> {
+		return this.execute().then((sub) => {
+			const off = sub.subscribe(handler);
+			return () => {
+				off();
+				void sub.kill();
+			};
+		});
+	}
+
+	// biome-ignore lint/suspicious/noThenProperty: makes the builder awaitable
+	then<R1 = LiveSubscription<V>, R2 = never>(
+		onFulfilled?:
+			| ((value: LiveSubscription<V>) => R1 | PromiseLike<R1>)
+			| undefined
+			| null,
+		onRejected?: ((reason: unknown) => R2 | PromiseLike<R2>) | undefined | null,
+	): Promise<R1 | R2> {
+		return this.execute().then(onFulfilled, onRejected);
+	}
+
+	catch<R = never>(
+		onRejected?: ((reason: unknown) => R | PromiseLike<R>) | undefined | null,
+	): Promise<LiveSubscription<V> | R> {
+		return this.execute().catch(onRejected);
+	}
+
+	finally(
+		onFinally?: (() => void) | undefined | null,
+	): Promise<LiveSubscription<V>> {
+		return this.execute().finally(onFinally);
+	}
+}

--- a/src/query/select.ts
+++ b/src/query/select.ts
@@ -38,7 +38,7 @@ type FieldKeys<O extends Orm, T extends keyof O["tables"] & string> =
  * segment is constrained to a known field; deeper segments are unconstrained,
  * mirroring SurrealDB which validates the rest of the path at query time.
  */
-type FetchPaths<O extends Orm, T extends keyof O["tables"] & string> =
+export type FetchPaths<O extends Orm, T extends keyof O["tables"] & string> =
 	| FieldKeys<O, T>
 	| `${FieldKeys<O, T>}.${string}`;
 
@@ -100,7 +100,7 @@ type FetchField<O extends Orm, F extends AbstractType, Tails extends string> = [
  * when it is the head of any fetch path; nested paths recurse into the resolved
  * schema. Matches SurrealDB, which expands intermediate records along a path.
  */
-type FetchedSchema<
+export type FetchedSchema<
 	O extends Orm,
 	E extends AbstractType,
 	Paths extends string,
@@ -384,7 +384,7 @@ export class SelectQuery<
  * head segment; each head is resolved once and any deeper segments recurse into
  * the resolved schema.
  */
-function resolveFetchObject(
+export function resolveFetchObject(
 	schema: ObjectType,
 	paths: string[],
 	orm: Orm,

--- a/src/schema/orm.ts
+++ b/src/schema/orm.ts
@@ -7,6 +7,7 @@ import { BatchQuery } from "../query/batch";
 import { CreateQuery } from "../query/create";
 import { DeleteQuery } from "../query/delete";
 import { InsertQuery } from "../query/insert";
+import { LiveQuery } from "../query/live";
 import { RelateQuery } from "../query/relate";
 import { SelectQuery } from "../query/select";
 import type { Transaction } from "../query/transaction";
@@ -112,6 +113,48 @@ export class Orm<T extends AnyTable[] = AnyTable[]> {
 			return new SelectQuery(this, tb as Workable<C, RecordType<Tb>>);
 		if (id === undefined) return new SelectQuery(this, tb as Tb);
 		return new SelectQuery(this, new RecordId(tb as Tb, id));
+	}
+
+	/**
+	 * Open a `LIVE SELECT` subscription for a table, record ID, or workable
+	 * record reference. Awaiting the returned builder runs the live query and
+	 * resolves to a {@link LiveSubscription}.
+	 *
+	 * @param tb - A table name, `RecordId`, workable record, or table name with a second `id` argument.
+	 * @returns A {@link LiveQuery} that can be chained (`.where()`, `.return()`, `.fetch()`, `.diff()`) and awaited.
+	 *
+	 * @remarks Filtering or projecting a live query relies on query parameters,
+	 *   which require **SurrealDB ≥ 3.0**.
+	 */
+	live<
+		C extends WorkableContext<this>,
+		Tb extends keyof this["tables"] & string,
+	>(tb: Tb): LiveQuery<this, C, Tb>;
+
+	// RecordId
+	live<
+		C extends WorkableContext<this>,
+		Tb extends keyof this["tables"] & string,
+	>(rid: RecordId<Tb>): LiveQuery<this, C, Tb>;
+	live<
+		C extends WorkableContext<this>,
+		Tb extends keyof this["tables"] & string,
+	>(rid: Workable<C, RecordType<Tb>>): LiveQuery<this, C, Tb>;
+	live<
+		C extends WorkableContext<this>,
+		Tb extends keyof this["tables"] & string,
+	>(tb: Tb, id: RecordIdValue): LiveQuery<this, C, Tb>;
+
+	// Method
+	live<
+		C extends WorkableContext<this>,
+		Tb extends keyof this["tables"] & string,
+	>(tb: Tb | RecordId<Tb> | Workable<C, RecordType<Tb>>, id?: RecordIdValue) {
+		if (tb instanceof RecordId) return new LiveQuery(this, tb);
+		if (isWorkable(tb))
+			return new LiveQuery(this, tb as Workable<C, RecordType<Tb>>);
+		if (id === undefined) return new LiveQuery(this, tb as Tb);
+		return new LiveQuery(this, new RecordId(tb as Tb, id));
 	}
 
 	/**

--- a/tests/integration/live.test.ts
+++ b/tests/integration/live.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test } from "bun:test";
+import type { LiveMessage, LiveSubscription } from "../../src";
+import { withTestDb } from "./setup";
+
+/** Reject if `promise` does not settle within `ms`, so a missing live
+ * notification fails the test instead of hanging. */
+function withTimeout<T>(
+	promise: Promise<T>,
+	ms: number,
+	label = "live notification",
+): Promise<T> {
+	return Promise.race([
+		promise,
+		new Promise<T>((_, reject) =>
+			setTimeout(() => reject(new Error(`timed out waiting for ${label}`)), ms),
+		),
+	]);
+}
+
+/** Resolve with the next `count` notifications (optionally filtered by action). */
+function collect<T>(
+	sub: LiveSubscription<T>,
+	count: number,
+	action?: LiveMessage<T>["action"],
+): Promise<LiveMessage<T>[]> {
+	return new Promise((resolve) => {
+		const messages: LiveMessage<T>[] = [];
+		const off = sub.subscribe((message) => {
+			if (action && message.action !== action) return;
+			messages.push(message);
+			if (messages.length >= count) {
+				off();
+				resolve(messages);
+			}
+		});
+	});
+}
+
+describe("Live query integration tests", () => {
+	// SurrealDB rejects `LIVE SELECT` against a table that does not exist, and
+	// these tests subscribe before any record is created — so define the tables
+	// up front (as a real app would).
+	const getTestDb = withTestDb({
+		perTest: true,
+		setup: async ({ surreal }) => {
+			await surreal.query(
+				"DEFINE TABLE user SCHEMALESS; DEFINE TABLE post SCHEMALESS;",
+			);
+		},
+	});
+
+	test("delivers CREATE / UPDATE / DELETE notifications with parsed values", async () => {
+		const { db } = getTestDb();
+
+		const sub = await db.live("user");
+		// Subscribe before mutating so no notifications are missed.
+		const received = collect(sub, 3);
+
+		await db
+			.create("user", "live_user")
+			.set({
+				name: { first: "John", last: "Doe" },
+				age: 30,
+				email: "john@example.com",
+				created: new Date(),
+				updated: new Date(),
+			})
+			.execute();
+		await db.update("user", "live_user").merge({ age: 31 }).execute();
+		await db.delete("user", "live_user").execute();
+
+		const messages = await withTimeout(received, 10_000);
+
+		expect(messages.map((m) => m.action)).toEqual([
+			"CREATE",
+			"UPDATE",
+			"DELETE",
+		]);
+		// Value is parsed against the schema (nested object survives).
+		expect(messages[0]!.value.name.first).toBe("John");
+		expect(messages[0]!.value.age).toBe(30);
+		expect(messages[1]!.value.age).toBe(31);
+		expect(messages[0]!.recordId.id).toBe("live_user");
+
+		await sub.kill();
+	}, 15_000);
+
+	test("filters notifications with WHERE (requires SurrealDB >= 3.0)", async () => {
+		const { db } = getTestDb();
+
+		const sub = await db.live("user").where(($this) => $this.age.gte(18));
+		const received = collect(sub, 1, "CREATE");
+
+		// Under-18 is filtered out; the adult is the first delivered CREATE.
+		await db
+			.create("user", "minor")
+			.set({
+				name: { first: "Kid", last: "Young" },
+				age: 10,
+				email: "kid@example.com",
+				created: new Date(),
+				updated: new Date(),
+			})
+			.execute();
+		await db
+			.create("user", "adult")
+			.set({
+				name: { first: "Grown", last: "Up" },
+				age: 30,
+				email: "grown@example.com",
+				created: new Date(),
+				updated: new Date(),
+			})
+			.execute();
+
+		const [message] = await withTimeout(received, 10_000);
+
+		expect(message!.value.age).toBe(30);
+		expect(message!.recordId.id).toBe("adult");
+
+		await sub.kill();
+	}, 15_000);
+
+	test("the .subscribe() shortcut starts the query and returns a stop function", async () => {
+		const { db } = getTestDb();
+
+		let resolveFirst: (message: LiveMessage<unknown>) => void;
+		const first = new Promise<LiveMessage<unknown>>((resolve) => {
+			resolveFirst = resolve;
+		});
+
+		const stop = await db.live("user").subscribe((message) => {
+			resolveFirst(message);
+		});
+
+		await db
+			.create("user")
+			.set({
+				name: { first: "Eve", last: "Stone" },
+				age: 42,
+				email: "eve@example.com",
+				created: new Date(),
+				updated: new Date(),
+			})
+			.execute();
+
+		const message = await withTimeout(first, 10_000);
+		expect(message.action).toBe("CREATE");
+
+		stop();
+	}, 15_000);
+});

--- a/tests/unit/query/live.test.ts
+++ b/tests/unit/query/live.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test";
+import { Surreal, Table } from "surrealdb";
+import { __display, displayContext, orm, t, table } from "../../../src";
+
+describe("LIVE SELECT queries", () => {
+	const user = table("user", {
+		name: t.object({
+			first: t.string(),
+			last: t.string(),
+		}),
+		age: t.number(),
+		email: t.string(),
+		tags: t.array(t.string()),
+	});
+
+	const post = table("post", {
+		title: t.string(),
+		body: t.string(),
+		author: t.record("user"),
+	});
+
+	const db = orm(new Surreal(), user, post);
+
+	test("generates basic LIVE SELECT", () => {
+		const query = db.live("user");
+		const ctx = displayContext();
+		const result = query[__display](ctx);
+
+		expect(result).toContain("LIVE SELECT * FROM");
+		expect(Object.values(ctx.variables)).toContainEqual(new Table("user"));
+	});
+
+	test("generates LIVE SELECT with WHERE", () => {
+		const query = db.live("user").where(($this) => $this.age.gt(18));
+		const ctx = displayContext();
+		const result = query[__display](ctx);
+
+		expect(result).toContain("LIVE SELECT * FROM");
+		expect(result).toContain("WHERE");
+		expect(result).toContain(">");
+	});
+
+	test("generates LIVE SELECT DIFF", () => {
+		const query = db.live("user").diff();
+		const ctx = displayContext();
+		const result = query[__display](ctx);
+
+		expect(result).toContain("LIVE SELECT DIFF FROM");
+	});
+
+	test("generates LIVE SELECT with VALUE projection via return", () => {
+		const query = db.live("user").return(($this) => ({
+			name: $this.name,
+			email: $this.email,
+		}));
+		const ctx = displayContext();
+		const result = query[__display](ctx);
+
+		expect(result).toContain("LIVE SELECT VALUE");
+		expect(result).toContain("email");
+	});
+
+	test("generates LIVE SELECT with FETCH", () => {
+		const query = db.live("post").fetch("author");
+		const ctx = displayContext();
+		const result = query[__display](ctx);
+
+		expect(result).toContain("LIVE SELECT * FROM");
+		expect(result).toContain("FETCH author");
+	});
+
+	test("combines WHERE and FETCH", () => {
+		const query = db
+			.live("post")
+			.where(($this) => $this.title.contains("hello"))
+			.fetch("author");
+		const ctx = displayContext();
+		const result = query[__display](ctx);
+
+		expect(result).toContain("LIVE SELECT * FROM");
+		expect(result).toContain("WHERE");
+		expect(result).toContain("FETCH author");
+	});
+
+	test("does not emit clauses unsupported by LIVE SELECT", () => {
+		const query = db.live("user").where(($this) => $this.age.gte(18));
+		const ctx = displayContext();
+		const result = query[__display](ctx);
+
+		expect(result).not.toContain("LIMIT");
+		expect(result).not.toContain("START");
+		expect(result).not.toContain("ORDER BY");
+		expect(result).not.toContain("GROUP");
+	});
+});


### PR DESCRIPTION
Implements #20 — support for SurrealDB Live Queries.

## What

Adds a `db.live(table)` builder that compiles to a SurrealDB `LIVE SELECT` statement and resolves to a typed `LiveSubscription`.

```ts
const sub = await db.live("user").where((u) => u.age.gte(18));

const off = sub.subscribe((msg) => {
  // msg.action:   "CREATE" | "UPDATE" | "DELETE" | "KILLED"
  // msg.recordId: RecordId
  // msg.value:    the affected record, parsed against the schema
});

for await (const msg of sub) { /* … */ }
await sub.kill();
```

## API

- Full parity with `select`: `.where()`, `.return()` (VALUE projection), `.fetch()` (resolves record links).
- `.diff()` → `LIVE SELECT DIFF`, retyping notifications to `JsonPatchOp[]`.
- Awaiting the builder → `LiveSubscription` with `.subscribe(handler)`, async iteration, `.kill()`, `.id`.
- Builder `.subscribe(handler)` shortcut → starts the query and returns a stop function that unsubscribes **and** kills.
- Built on the SDK's unmanaged path (`query()` → `liveOf()`), reusing surqlize's existing display/binding and the `resolveFetchObject` / `FetchPaths` / `FetchedSchema` helpers from `select.ts` (now exported).

## Notes / caveats

- Filtering or projecting a live query relies on query parameters, which require **SurrealDB ≥ 3.0** (`FETCH` requires ≥ 2.2.0). Documented in JSDoc + README.
- The table must exist before subscribing (SurrealDB 3.x errors on `LIVE SELECT` against an undefined table).
- Subscriptions are **unmanaged** — not automatically restarted on reconnect.

## Tests

- Unit tests asserting the compiled `LIVE SELECT` strings (basic / WHERE / DIFF / VALUE / FETCH / unsupported-clause negative).
- Integration tests (gated on a local SurrealDB): CREATE/UPDATE/DELETE lifecycle with parsed values, WHERE filtering (verified against SurrealDB 3.1.2), and the `.subscribe()` shortcut.

`bun run all` (test + type-check + biome) passes.