### PR TITLE
Make query builders immutable and harden identifier rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,17 @@ bun add surqlize
 npm install surqlize
 ```
 
+### Requirements
+
+- **SurrealDB server ≥ 3.0** — surqlize targets the SurrealDB 3.x server. Some
+  features degrade or are unavailable on older servers; for example, filtering
+  or projecting a live query relies on query parameters that require **server ≥
+  3.0** (`FETCH` requires ≥ 2.2.0).
+- **`surrealdb` JavaScript SDK ≥ 2.0.0-alpha.18** — declared as a peer
+  dependency, so install it alongside surqlize. (The SDK and the server are
+  versioned independently: the 2.x SDK is what connects to a 3.x server.)
+- **TypeScript ≥ 5.0** for full type inference.
+
 ## Quick start
 
 ```typescript

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
 	"files": [
 		"dist"
 	],
+	"sideEffects": false,
 	"license": "Apache-2.0",
 	"devDependencies": {
 		"@biomejs/biome": "^2.3.15",
@@ -37,7 +38,7 @@
 		"tsup": "^8.5.1"
 	},
 	"peerDependencies": {
-		"surrealdb": "^2.0.0-alpha.18",
+		"surrealdb": ">=2.0.0-alpha.18",
 		"typescript": "^5.0.0"
 	},
 	"scripts": {

--- a/src/query/abstract.ts
+++ b/src/query/abstract.ts
@@ -54,6 +54,25 @@ export abstract class Query<
 		return Object.assign(Object.create(Object.getPrototypeOf(this)), this);
 	}
 
+	/**
+	 * Return a shallow {@link clone} of this query with `mutate` applied to it.
+	 *
+	 * This is the basis of the immutable builder API: every chaining method
+	 * (`.where()`, `.limit()`, …) derives a *new* query rather than mutating
+	 * `this`, so a partially-built query can be safely reused as the base for
+	 * several divergent queries without their state leaking into one another.
+	 *
+	 * Because the clone is shallow, `mutate` must replace mutable fields
+	 * wholesale (e.g. `next._orderBy = [...next._orderBy ?? [], entry]`) instead
+	 * of mutating them in place — an in-place `push`/property write would also
+	 * affect the original query, which shares the same array/object references.
+	 */
+	protected derive(mutate: (draft: this) => void): this {
+		const next = this.clone();
+		mutate(next);
+		return next;
+	}
+
 	/** Render the query as a SurrealQL string. */
 	toString(): string {
 		const ctx = displayContext();

--- a/src/query/create.ts
+++ b/src/query/create.ts
@@ -84,30 +84,27 @@ export class CreateQuery<
 	}
 
 	set(data: E extends ObjectType ? Partial<SetData<E>> : never): this {
-		applySet(this, data as Record<string, unknown>);
-		return this;
+		return this.derive((next) =>
+			applySet(next, data as Record<string, unknown>),
+		);
 	}
 
 	content(
 		data: E extends ObjectType ? Omit<E["infer"], "id"> : E["infer"],
 	): this {
-		applyContent(this, data);
-		return this;
+		return this.derive((next) => applyContent(next, data));
 	}
 
 	merge(data: Partial<E["infer"]>): this {
-		applyMerge(this, data);
-		return this;
+		return this.derive((next) => applyMerge(next, data));
 	}
 
 	patch(operations: JsonPatchOp[]): this {
-		applyPatch(this, operations);
-		return this;
+		return this.derive((next) => applyPatch(next, operations));
 	}
 
 	replace(data: Partial<E["infer"]>): this {
-		applyReplace(this, data);
-		return this;
+		return this.derive((next) => applyReplace(next, data));
 	}
 
 	return(mode: "none" | "before" | "after" | "diff"): this;
@@ -133,17 +130,22 @@ export class CreateQuery<
 
 			const inheritable = value(record);
 			const workable = inheritableIntoWorkable(inheritable);
-			this._return = sanitizeWorkable(workable) as Workable<C>;
-		} else {
-			this._return = value;
-			this._skipParse = value === "diff";
+			const ret = sanitizeWorkable(workable) as Workable<C>;
+			return this.derive((next) => {
+				next._return = ret;
+			});
 		}
-		return this;
+		const mode = value;
+		return this.derive((next) => {
+			next._return = mode;
+			next._skipParse = mode === "diff";
+		});
 	}
 
 	timeout(duration: string): this {
-		this._timeout = duration;
-		return this;
+		return this.derive((next) => {
+			next._timeout = duration;
+		});
 	}
 
 	[__display](inp: DisplayContext) {

--- a/src/query/delete.ts
+++ b/src/query/delete.ts
@@ -78,8 +78,10 @@ export class DeleteQuery<
 			},
 		}) as Actionable<C, O["tables"][T]["schema"]>;
 
-		this._filter = sanitizeWorkable(cb(tb));
-		return this;
+		const filter = sanitizeWorkable(cb(tb));
+		return this.derive((next) => {
+			next._filter = filter;
+		});
 	}
 
 	return(mode: "none" | "before" | "after" | "diff"): this;
@@ -108,17 +110,22 @@ export class DeleteQuery<
 			const workable = inheritableIntoWorkable<C, typeof predicable>(
 				predicable,
 			) as unknown as Workable<C, E>;
-			this._return = sanitizeWorkable(workable);
-		} else {
-			this._return = value;
-			this._skipParse = value === "diff";
+			const ret = sanitizeWorkable(workable);
+			return this.derive((next) => {
+				next._return = ret;
+			});
 		}
-		return this;
+		const mode = value;
+		return this.derive((next) => {
+			next._return = mode;
+			next._skipParse = mode === "diff";
+		});
 	}
 
 	timeout(duration: string): this {
-		this._timeout = duration;
-		return this;
+		return this.derive((next) => {
+			next._timeout = duration;
+		});
 	}
 
 	[__display](inp: DisplayContext) {

--- a/src/query/insert.ts
+++ b/src/query/insert.ts
@@ -1,4 +1,4 @@
-import { Table } from "surrealdb";
+import { escapeIdent, Table } from "surrealdb";
 import { OrmError } from "../error.ts";
 import type { Orm } from "../schema/orm.ts";
 import {
@@ -88,8 +88,10 @@ export class InsertQuery<
 		if (this._data) {
 			throw new OrmError("Cannot use fields() with object-style insert");
 		}
-		this._fields = fields as string[];
-		return this;
+		const fields_ = fields as string[];
+		return this.derive((next) => {
+			next._fields = fields_;
+		});
 	}
 
 	/**
@@ -117,8 +119,9 @@ export class InsertQuery<
 			}
 		}
 
-		this._values = [...(this._values || []), ...rows];
-		return this;
+		return this.derive((next) => {
+			next._values = [...(next._values ?? []), ...rows];
+		});
 	}
 
 	/**
@@ -130,8 +133,9 @@ export class InsertQuery<
 		if (this._onDuplicate) {
 			throw new OrmError("Cannot use both ignore() and onDuplicate()");
 		}
-		this._ignore = true;
-		return this;
+		return this.derive((next) => {
+			next._ignore = true;
+		});
 	}
 
 	/**
@@ -152,8 +156,9 @@ export class InsertQuery<
 		const processedData = processSetOperators(
 			updates as Record<string, unknown>,
 		);
-		this._onDuplicate = processedData;
-		return this;
+		return this.derive((next) => {
+			next._onDuplicate = processedData;
+		});
 	}
 
 	return(mode: "none" | "before" | "after" | "diff"): this;
@@ -182,17 +187,22 @@ export class InsertQuery<
 			const workable = inheritableIntoWorkable<C, typeof predicable>(
 				predicable,
 			) as unknown as Workable<C, E>;
-			this._return = sanitizeWorkable(workable);
-		} else {
-			this._return = value;
-			this._skipParse = value === "diff";
+			const ret = sanitizeWorkable(workable);
+			return this.derive((next) => {
+				next._return = ret;
+			});
 		}
-		return this;
+		const mode = value;
+		return this.derive((next) => {
+			next._return = mode;
+			next._skipParse = mode === "diff";
+		});
 	}
 
 	timeout(duration: string): this {
-		this._timeout = duration;
-		return this;
+		return this.derive((next) => {
+			next._timeout = duration;
+		});
 	}
 
 	[__display](inp: DisplayContext) {
@@ -214,7 +224,7 @@ export class InsertQuery<
 
 		// VALUES tuple syntax
 		else if (this._fields && this._values) {
-			query += /* surql */ ` (${this._fields.join(", ")})`;
+			query += /* surql */ ` (${this._fields.map(escapeIdent).join(", ")})`;
 			const valueGroups = this._values.map(
 				(row) => `(${row.map((v) => ctx.var(v)).join(", ")})`,
 			);

--- a/src/query/live.ts
+++ b/src/query/live.ts
@@ -29,6 +29,7 @@ import {
 	type FetchPaths,
 	resolveFetchObject,
 } from "./select.ts";
+import { escapeIdiomPath } from "./utils.ts";
 
 /** The underlying SDK subscription returned by `surreal.liveOf()`. */
 type SdkLiveSubscription = Awaited<ReturnType<SurrealSession["liveOf"]>>;
@@ -159,6 +160,23 @@ export class LiveQuery<
 		return this.entry;
 	}
 
+	/** Create a shallow clone of this live query. */
+	private clone(): this {
+		return Object.assign(Object.create(Object.getPrototypeOf(this)), this);
+	}
+
+	/**
+	 * Return a shallow {@link clone} with `mutate` applied. Mirrors
+	 * `Query.derive`: chaining methods derive a new builder instead of mutating
+	 * `this`, so a base live query can be safely reused. Mutations must replace
+	 * mutable fields wholesale rather than mutating them in place.
+	 */
+	private derive(mutate: (draft: this) => void): this {
+		const next = this.clone();
+		mutate(next);
+		return next;
+	}
+
 	return<
 		P extends Inheritable<C>,
 		R extends InheritableIntoType<C, P> = InheritableIntoType<C, P>,
@@ -177,8 +195,9 @@ export class LiveQuery<
 		) as unknown as Workable<C, R>;
 		const entry = sanitizeWorkable(workable);
 
-		(this as unknown as LiveQuery<O, C, T, R, R["infer"]>)._entry = entry;
-		return this as unknown as LiveQuery<O, C, T, R, R["infer"]>;
+		return this.derive((next) => {
+			(next as unknown as LiveQuery<O, C, T, R, R["infer"]>)._entry = entry;
+		}) as unknown as LiveQuery<O, C, T, R, R["infer"]>;
 	}
 
 	where(
@@ -192,8 +211,10 @@ export class LiveQuery<
 			},
 		}) as Actionable<C, O["tables"][T]["schema"]>;
 
-		this._filter = sanitizeWorkable(cb(tb));
-		return this;
+		const filter = sanitizeWorkable(cb(tb));
+		return this.derive((next) => {
+			next._filter = filter;
+		});
 	}
 
 	fetch<P extends FetchPaths<O, T>>(
@@ -205,21 +226,19 @@ export class LiveQuery<
 		FetchedSchema<O, E, P>,
 		FetchedSchema<O, E, P>["infer"]
 	> {
-		this._fetch = fields;
-
 		// Reuse SelectQuery's resolved-schema logic so notification values are
 		// validated as the resolved records instead of expecting RecordIds.
 		const currentSchema =
 			this._entry?.[__type] ?? this[__ctx].orm.tables[this.tb]!.schema;
-		if (currentSchema instanceof ObjectType) {
-			this._fetchResolvedType = resolveFetchObject(
-				currentSchema,
-				fields,
-				this[__ctx].orm,
-			);
-		}
+		const resolved =
+			currentSchema instanceof ObjectType
+				? resolveFetchObject(currentSchema, fields, this[__ctx].orm)
+				: undefined;
 
-		return this as unknown as LiveQuery<
+		return this.derive((next) => {
+			next._fetch = fields;
+			if (resolved) next._fetchResolvedType = resolved;
+		}) as unknown as LiveQuery<
 			O,
 			C,
 			T,
@@ -233,8 +252,9 @@ export class LiveQuery<
 	 * records. Mutually exclusive with a `.return()` projection.
 	 */
 	diff(): LiveQuery<O, C, T, E, JsonPatchOp[]> {
-		this._diff = true;
-		return this as unknown as LiveQuery<O, C, T, E, JsonPatchOp[]>;
+		return this.derive((next) => {
+			next._diff = true;
+		}) as unknown as LiveQuery<O, C, T, E, JsonPatchOp[]>;
 	}
 
 	private displaySubject(ctx: DisplayContext): string {
@@ -263,7 +283,7 @@ export class LiveQuery<
 			query += /* surql */ ` WHERE ${this._filter[__display](ctx)}`;
 
 		if (this._fetch && this._fetch.length > 0)
-			query += /* surql */ ` FETCH ${this._fetch.join(", ")}`;
+			query += /* surql */ ` FETCH ${this._fetch.map(escapeIdiomPath).join(", ")}`;
 
 		return query;
 	}

--- a/src/query/modification-methods.ts
+++ b/src/query/modification-methods.ts
@@ -2,6 +2,7 @@ import { OrmError } from "../error.ts";
 import type { ObjectType } from "../types";
 import type { DisplayContext } from "../utils/display.ts";
 import {
+	escapeIdiomPath,
 	generateSetAssignments,
 	processSetOperators,
 	type SetValue,
@@ -143,7 +144,7 @@ function displaySetUnsetClause(
 	}
 
 	if (state._unset && state._unset.length > 0) {
-		parts.push(`UNSET ${state._unset.join(", ")}`);
+		parts.push(`UNSET ${state._unset.map(escapeIdiomPath).join(", ")}`);
 	}
 
 	return parts.length > 0 ? ` ${parts.join(" ")}` : "";

--- a/src/query/relate.ts
+++ b/src/query/relate.ts
@@ -93,8 +93,9 @@ export class RelateQuery<
 	}
 
 	set(data: E extends ObjectType ? Partial<SetData<E>> : never): this {
-		applySet(this, data as Record<string, unknown>);
-		return this;
+		return this.derive((next) =>
+			applySet(next, data as Record<string, unknown>),
+		);
 	}
 
 	content(
@@ -102,23 +103,19 @@ export class RelateQuery<
 			? Omit<E["infer"], "id" | "in" | "out">
 			: E["infer"],
 	): this {
-		applyContent(this, data);
-		return this;
+		return this.derive((next) => applyContent(next, data));
 	}
 
 	merge(data: Partial<E["infer"]>): this {
-		applyMerge(this, data);
-		return this;
+		return this.derive((next) => applyMerge(next, data));
 	}
 
 	patch(operations: JsonPatchOp[]): this {
-		applyPatch(this, operations);
-		return this;
+		return this.derive((next) => applyPatch(next, operations));
 	}
 
 	replace(data: Partial<E["infer"]>): this {
-		applyReplace(this, data);
-		return this;
+		return this.derive((next) => applyReplace(next, data));
 	}
 
 	return(mode: "none" | "before" | "after" | "diff"): this;
@@ -144,17 +141,22 @@ export class RelateQuery<
 
 			const inheritable = value(record);
 			const workable = inheritableIntoWorkable(inheritable) as Workable<C, E>;
-			this._return = sanitizeWorkable(workable);
-		} else {
-			this._return = value;
-			this._skipParse = value === "diff";
+			const ret = sanitizeWorkable(workable);
+			return this.derive((next) => {
+				next._return = ret;
+			});
 		}
-		return this;
+		const mode = value;
+		return this.derive((next) => {
+			next._return = mode;
+			next._skipParse = mode === "diff";
+		});
 	}
 
 	timeout(duration: string): this {
-		this._timeout = duration;
-		return this;
+		return this.derive((next) => {
+			next._timeout = duration;
+		});
 	}
 
 	[__display](inp: DisplayContext) {

--- a/src/query/select.ts
+++ b/src/query/select.ts
@@ -26,6 +26,7 @@ import {
 	type WorkableContext,
 } from "../utils/workable.ts";
 import { Query } from "./abstract.ts";
+import { escapeIdiomPath } from "./utils.ts";
 
 type FieldKeys<O extends Orm, T extends keyof O["tables"] & string> =
 	O["tables"][T]["schema"] extends ObjectType<infer F>
@@ -194,8 +195,9 @@ export class SelectQuery<
 		) as unknown as Workable<C, R>;
 		const entry = sanitizeWorkable(workable);
 
-		(this as unknown as SelectQuery<O, C, T, R>)._entry = entry;
-		return this as unknown as SelectQuery<O, C, T, R>;
+		return this.derive((next) => {
+			(next as unknown as SelectQuery<O, C, T, R>)._entry = entry;
+		}) as unknown as SelectQuery<O, C, T, R>;
 	}
 
 	where(cb: (tb: Actionable<C, O["tables"][T]["schema"]>) => Workable<C>) {
@@ -207,18 +209,22 @@ export class SelectQuery<
 			},
 		}) as Actionable<C, O["tables"][T]["schema"]>;
 
-		this._filter = sanitizeWorkable(cb(tb));
-		return this;
+		const filter = sanitizeWorkable(cb(tb));
+		return this.derive((next) => {
+			next._filter = filter;
+		});
 	}
 
 	start(start: number) {
-		this._start = start;
-		return this;
+		return this.derive((next) => {
+			next._start = start;
+		});
 	}
 
 	limit(limit: number) {
-		this._limit = limit;
-		return this;
+		return this.derive((next) => {
+			next._limit = limit;
+		});
 	}
 
 	private _addOrderBy(
@@ -226,24 +232,27 @@ export class SelectQuery<
 		direction?: "ASC" | "DESC",
 		opts?: { collate?: boolean; numeric?: boolean },
 	): this {
-		if (!this._orderBy) this._orderBy = [];
-		if (typeof field === "string") {
-			this._orderBy.push({ field, direction, ...opts });
-		} else {
-			const record = actionable({
-				[__ctx]: this[__ctx],
-				[__type]: this.entry,
-				[__display]: ({ contextId }) => {
-					return contextId === this[__ctx].id ? "$this" : "$parent";
-				},
-			}) as Actionable<C, E>;
-			this._orderBy.push({
-				field: sanitizeWorkable(field(record)),
-				direction,
-				...opts,
-			});
-		}
-		return this;
+		const entry =
+			typeof field === "string"
+				? { field, direction, ...opts }
+				: {
+						field: sanitizeWorkable(
+							field(
+								actionable({
+									[__ctx]: this[__ctx],
+									[__type]: this.entry,
+									[__display]: ({ contextId }) => {
+										return contextId === this[__ctx].id ? "$this" : "$parent";
+									},
+								}) as Actionable<C, E>,
+							),
+						),
+						direction,
+						...opts,
+					};
+		return this.derive((next) => {
+			next._orderBy = [...(next._orderBy ?? []), entry];
+		});
 	}
 
 	orderBy(
@@ -268,25 +277,26 @@ export class SelectQuery<
 	}
 
 	groupBy(...fields: FieldKeys<O, T>[]): this {
-		this._groupBy = fields;
-		return this;
+		return this.derive((next) => {
+			next._groupBy = fields;
+		});
 	}
 
 	groupAll(): this {
-		this._groupBy = "ALL";
-		return this;
+		return this.derive((next) => {
+			next._groupBy = "ALL";
+		});
 	}
 
 	split(...fields: FieldKeys<O, T>[]): this {
-		this._split = fields;
-		return this;
+		return this.derive((next) => {
+			next._split = fields;
+		});
 	}
 
 	fetch<P extends FetchPaths<O, T>>(
 		...fields: P[]
 	): SelectQuery<O, C, T, FetchedSchema<O, E, P>> {
-		this._fetch = fields;
-
 		// Build a resolved schema where fetched record references are replaced
 		// with the referenced table's ObjectType schema, recursing into nested
 		// paths so parse() validates the resolved objects instead of expecting
@@ -294,20 +304,21 @@ export class SelectQuery<
 		// `out.author` resolves both `out` and its nested `author`.
 		const currentSchema =
 			this._entry?.[__type] ?? this[__ctx].orm.tables[this.tb]!.schema;
-		if (currentSchema instanceof ObjectType) {
-			this._fetchResolvedType = resolveFetchObject(
-				currentSchema,
-				fields,
-				this[__ctx].orm,
-			);
-		}
+		const resolved =
+			currentSchema instanceof ObjectType
+				? resolveFetchObject(currentSchema, fields, this[__ctx].orm)
+				: undefined;
 
-		return this as unknown as SelectQuery<O, C, T, FetchedSchema<O, E, P>>;
+		return this.derive((next) => {
+			next._fetch = fields;
+			if (resolved) next._fetchResolvedType = resolved;
+		}) as unknown as SelectQuery<O, C, T, FetchedSchema<O, E, P>>;
 	}
 
 	timeout(duration: string): this {
-		this._timeout = duration;
-		return this;
+		return this.derive((next) => {
+			next._timeout = duration;
+		});
 	}
 
 	private displaySubject(ctx: DisplayContext): string {
@@ -322,7 +333,7 @@ export class SelectQuery<
 		const orderParts = this._orderBy.map((spec) => {
 			let part =
 				typeof spec.field === "string"
-					? spec.field
+					? escapeIdiomPath(spec.field)
 					: spec.field[__display](ctx);
 
 			if (spec.collate) part += " COLLATE";
@@ -354,13 +365,13 @@ export class SelectQuery<
 			query += /* surql */ ` WHERE ${this._filter[__display](ctx)}`;
 
 		if (this._split && this._split.length > 0)
-			query += /* surql */ ` SPLIT ${this._split.join(", ")}`;
+			query += /* surql */ ` SPLIT ${this._split.map(escapeIdiomPath).join(", ")}`;
 
 		if (this._groupBy) {
 			query +=
 				this._groupBy === "ALL"
 					? " GROUP ALL"
-					: /* surql */ ` GROUP BY ${this._groupBy.join(", ")}`;
+					: /* surql */ ` GROUP BY ${this._groupBy.map(escapeIdiomPath).join(", ")}`;
 		}
 
 		query += this.displayOrderBy(ctx);
@@ -369,7 +380,7 @@ export class SelectQuery<
 		if (start) query += /* surql */ ` START ${start}`;
 
 		if (this._fetch && this._fetch.length > 0)
-			query += /* surql */ ` FETCH ${this._fetch.join(", ")}`;
+			query += /* surql */ ` FETCH ${this._fetch.map(escapeIdiomPath).join(", ")}`;
 
 		if (this._timeout)
 			query += /* surql */ ` TIMEOUT ${ctx.var(this._timeout)}`;

--- a/src/query/update.ts
+++ b/src/query/update.ts
@@ -95,33 +95,29 @@ export class UpdateQuery<
 	}
 
 	set(data: E extends ObjectType ? Partial<SetData<E>> : never): this {
-		applySet(this, data as Record<string, unknown>);
-		return this;
+		return this.derive((next) =>
+			applySet(next, data as Record<string, unknown>),
+		);
 	}
 
 	unset(fields: E extends ObjectType ? (keyof E["schema"])[] : string[]): this {
-		applyUnset(this, fields as string[]);
-		return this;
+		return this.derive((next) => applyUnset(next, fields as string[]));
 	}
 
 	content(data: Partial<E["infer"]>): this {
-		applyContent(this, data);
-		return this;
+		return this.derive((next) => applyContent(next, data));
 	}
 
 	merge(data: Partial<E["infer"]>): this {
-		applyMerge(this, data);
-		return this;
+		return this.derive((next) => applyMerge(next, data));
 	}
 
 	patch(operations: JsonPatchOp[]): this {
-		applyPatch(this, operations);
-		return this;
+		return this.derive((next) => applyPatch(next, operations));
 	}
 
 	replace(data: Partial<E["infer"]>): this {
-		applyReplace(this, data);
-		return this;
+		return this.derive((next) => applyReplace(next, data));
 	}
 
 	where(cb: (tb: Actionable<C, O["tables"][T]["schema"]>) => Workable<C>) {
@@ -133,8 +129,10 @@ export class UpdateQuery<
 			},
 		}) as Actionable<C, O["tables"][T]["schema"]>;
 
-		this._filter = sanitizeWorkable(cb(tb));
-		return this;
+		const filter = sanitizeWorkable(cb(tb));
+		return this.derive((next) => {
+			next._filter = filter;
+		});
 	}
 
 	return(mode: "none" | "before" | "after" | "diff"): this;
@@ -163,17 +161,22 @@ export class UpdateQuery<
 			const workable = inheritableIntoWorkable<C, typeof predicable>(
 				predicable,
 			) as unknown as Workable<C, E>;
-			this._return = sanitizeWorkable(workable);
-		} else {
-			this._return = value;
-			this._skipParse = value === "diff";
+			const ret = sanitizeWorkable(workable);
+			return this.derive((next) => {
+				next._return = ret;
+			});
 		}
-		return this;
+		const mode = value;
+		return this.derive((next) => {
+			next._return = mode;
+			next._skipParse = mode === "diff";
+		});
 	}
 
 	timeout(duration: string): this {
-		this._timeout = duration;
-		return this;
+		return this.derive((next) => {
+			next._timeout = duration;
+		});
 	}
 
 	[__display](inp: DisplayContext) {

--- a/src/query/upsert.ts
+++ b/src/query/upsert.ts
@@ -94,28 +94,25 @@ export class UpsertQuery<
 	}
 
 	set(data: E extends ObjectType ? Partial<SetData<E>> : never): this {
-		applySet(this, data as Record<string, unknown>);
-		return this;
+		return this.derive((next) =>
+			applySet(next, data as Record<string, unknown>),
+		);
 	}
 
 	content(data: Partial<E["infer"]>): this {
-		applyContent(this, data);
-		return this;
+		return this.derive((next) => applyContent(next, data));
 	}
 
 	merge(data: Partial<E["infer"]>): this {
-		applyMerge(this, data);
-		return this;
+		return this.derive((next) => applyMerge(next, data));
 	}
 
 	patch(operations: JsonPatchOp[]): this {
-		applyPatch(this, operations);
-		return this;
+		return this.derive((next) => applyPatch(next, operations));
 	}
 
 	replace(data: Partial<E["infer"]>): this {
-		applyReplace(this, data);
-		return this;
+		return this.derive((next) => applyReplace(next, data));
 	}
 
 	where(cb: (tb: Actionable<C, O["tables"][T]["schema"]>) => Workable<C>) {
@@ -127,8 +124,10 @@ export class UpsertQuery<
 			},
 		}) as Actionable<C, O["tables"][T]["schema"]>;
 
-		this._filter = sanitizeWorkable(cb(tb));
-		return this;
+		const filter = sanitizeWorkable(cb(tb));
+		return this.derive((next) => {
+			next._filter = filter;
+		});
 	}
 
 	return(mode: "none" | "before" | "after" | "diff"): this;
@@ -157,17 +156,22 @@ export class UpsertQuery<
 			const workable = inheritableIntoWorkable<C, typeof predicable>(
 				predicable,
 			) as unknown as Workable<C, E>;
-			this._return = sanitizeWorkable(workable);
-		} else {
-			this._return = value;
-			this._skipParse = value === "diff";
+			const ret = sanitizeWorkable(workable);
+			return this.derive((next) => {
+				next._return = ret;
+			});
 		}
-		return this;
+		const mode = value;
+		return this.derive((next) => {
+			next._return = mode;
+			next._skipParse = mode === "diff";
+		});
 	}
 
 	timeout(duration: string): this {
-		this._timeout = duration;
-		return this;
+		return this.derive((next) => {
+			next._timeout = duration;
+		});
 	}
 
 	[__display](inp: DisplayContext) {

--- a/src/query/utils.ts
+++ b/src/query/utils.ts
@@ -1,5 +1,20 @@
+import { escapeIdent } from "surrealdb";
 import type { AbstractType } from "../types";
 import type { DisplayContext } from "../utils";
+
+/**
+ * Escape a dotted SurrealQL idiom path (e.g. `out.author`) segment by segment.
+ *
+ * Field identifiers are interpolated directly into the rendered query — unlike
+ * values, which are bound as parameters — so each segment is passed through the
+ * SDK's `escapeIdent`: bare identifiers are emitted unchanged, while names that
+ * are not valid bare identifiers (spaces, punctuation, leading digits, …) are
+ * safely quoted. The `.` separators that drive record-link traversal are
+ * preserved between segments.
+ */
+export function escapeIdiomPath(path: string): string {
+	return path.split(".").map(escapeIdent).join(".");
+}
 
 export type SetValue<T extends AbstractType> =
 	| T["infer"]
@@ -40,16 +55,17 @@ export function generateSetAssignments(
 ): string[] {
 	const assignments: string[] = [];
 	for (const [key, value] of Object.entries(data)) {
+		const field = escapeIdiomPath(key);
 		if (value && typeof value === "object" && "+=" in value) {
 			assignments.push(
-				`${key} += ${ctx.var((value as { "+=": unknown })["+="])}`,
+				`${field} += ${ctx.var((value as { "+=": unknown })["+="])}`,
 			);
 		} else if (value && typeof value === "object" && "-=" in value) {
 			assignments.push(
-				`${key} -= ${ctx.var((value as { "-=": unknown })["-="])}`,
+				`${field} -= ${ctx.var((value as { "-=": unknown })["-="])}`,
 			);
 		} else {
-			assignments.push(`${key} = ${ctx.var(value)}`);
+			assignments.push(`${field} = ${ctx.var(value)}`);
 		}
 	}
 	return assignments;

--- a/tests/unit/query/identifier-escaping.test.ts
+++ b/tests/unit/query/identifier-escaping.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+import { Surreal } from "surrealdb";
+import { orm, t, table } from "../../../src";
+
+/**
+ * Field identifiers are interpolated directly into the rendered SurrealQL (only
+ * values are bound as parameters), so any field name that is not a bare
+ * identifier must be quoted with SurrealDB's `⟨…⟩` form. These tests use a
+ * schema whose field names require escaping to pin that behaviour, and also
+ * assert that ordinary names are emitted unchanged.
+ */
+describe("identifier escaping", () => {
+	// Field names that are NOT bare SurrealQL identifiers.
+	const user = table("user", {
+		"first name": t.string(),
+		"x; DROP": t.number(),
+		age: t.number(),
+	});
+
+	const post = table("post", {
+		title: t.string(),
+		author: t.record("user"),
+	});
+
+	const db = orm(new Surreal(), user, post);
+
+	test("ORDER BY quotes non-identifier field names", () => {
+		const sql = db.select("user").orderBy("first name").toString();
+		expect(sql).toContain("ORDER BY ⟨first name⟩");
+	});
+
+	test("GROUP BY and SPLIT quote non-identifier field names", () => {
+		expect(db.select("user").groupBy("first name").toString()).toContain(
+			"GROUP BY ⟨first name⟩",
+		);
+		expect(db.select("user").split("x; DROP").toString()).toContain(
+			"SPLIT ⟨x; DROP⟩",
+		);
+	});
+
+	test("SET assignments quote non-identifier field names", () => {
+		const sql = db.update("user").set({ "first name": "ada" }).toString();
+		expect(sql).toContain("⟨first name⟩ =");
+		// The value itself is still bound as a parameter, not inlined.
+		expect(sql).not.toContain("ada");
+	});
+
+	test("UNSET quotes non-identifier field names", () => {
+		const sql = db.update("user").unset(["first name"]).toString();
+		expect(sql).toContain("UNSET ⟨first name⟩");
+	});
+
+	test("INSERT column list quotes non-identifier field names", () => {
+		const sql = db
+			.insert("user")
+			.fields(["first name"])
+			.values(["ada"])
+			.toString();
+		expect(sql).toContain("(⟨first name⟩)");
+	});
+
+	test("a SurrealQL-injection attempt in a field name is neutralised", () => {
+		const sql = db.select("user").orderBy("x; DROP").toString();
+		// Quoted as a single identifier — the `;` cannot terminate the statement.
+		expect(sql).toContain("⟨x; DROP⟩");
+		expect(sql).not.toContain("ORDER BY x; DROP");
+	});
+
+	test("ordinary identifiers are emitted unchanged", () => {
+		expect(db.select("user").orderBy("age").toString()).toContain(
+			"ORDER BY age",
+		);
+		expect(db.select("user").orderBy("age").toString()).not.toContain("⟨");
+
+		// Dotted FETCH paths keep their `.` separators and stay unquoted when each
+		// segment is a bare identifier.
+		const fetched = db.select("post").fetch("author").toString();
+		expect(fetched).toContain("FETCH author");
+		expect(fetched).not.toContain("⟨");
+	});
+});

--- a/tests/unit/query/immutability.test.ts
+++ b/tests/unit/query/immutability.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "bun:test";
+import { Surreal } from "surrealdb";
+import { __display, displayContext, orm, t, table } from "../../../src";
+
+/**
+ * Query builders are immutable: every chaining method returns a *new* builder
+ * rather than mutating `this`. These tests pin that contract so a half-built
+ * query can be safely reused as the base for several divergent queries without
+ * their state leaking into one another.
+ */
+describe("query builder immutability", () => {
+	const user = table("user", {
+		name: t.string(),
+		age: t.number(),
+		email: t.string(),
+	});
+
+	const db = orm(new Surreal(), user);
+
+	/** Render a query and return the parameter values it bound. */
+	function boundValues(query: {
+		[__display](ctx: ReturnType<typeof displayContext>): string;
+	}): unknown[] {
+		const ctx = displayContext();
+		query[__display](ctx);
+		return Object.values(ctx.variables);
+	}
+
+	test("chaining returns a new instance, never `this`", () => {
+		const base = db.select("user");
+		const filtered = base.where(($this) => $this.age.gt(18));
+		const limited = base.limit(5);
+
+		expect(filtered).not.toBe(base);
+		expect(limited).not.toBe(base);
+		expect(filtered).not.toBe(limited);
+	});
+
+	test("branching a SELECT does not leak state across branches", () => {
+		const base = db.select("user");
+		const filtered = base.where(($this) => $this.age.gt(18));
+		const limited = base.limit(5);
+
+		// The base is untouched by either branch.
+		const baseSql = base.toString();
+		expect(baseSql).toContain("SELECT * FROM");
+		expect(baseSql).not.toContain("WHERE");
+		expect(baseSql).not.toContain("LIMIT");
+
+		// Each branch carries only its own clause.
+		expect(filtered.toString()).toContain("WHERE");
+		expect(filtered.toString()).not.toContain("LIMIT");
+		expect(limited.toString()).toContain("LIMIT");
+		expect(limited.toString()).not.toContain("WHERE");
+	});
+
+	test("orderBy does not mutate the base's accumulated order list", () => {
+		// Guards the copy-on-write fix in `_addOrderBy` (previously an in-place
+		// `_orderBy.push`, which would corrupt every clone sharing the array).
+		const base = db.select("user").orderBy("age");
+		const both = base.orderBy("email");
+
+		expect(base.toString()).toContain("ORDER BY age");
+		expect(base.toString()).not.toContain("email");
+
+		expect(both.toString()).toContain("age");
+		expect(both.toString()).toContain("email");
+	});
+
+	test("branching SET-style modifications stays isolated", () => {
+		const base = db.update("user");
+		const byAge = base.set({ age: 30 });
+		const byEmail = base.set({ email: "a@b.c" });
+
+		expect(base.toString()).not.toContain("SET");
+		expect(byAge.toString()).toContain("age");
+		expect(byAge.toString()).not.toContain("email");
+		expect(byEmail.toString()).toContain("email");
+		expect(byEmail.toString()).not.toContain("age");
+	});
+
+	test("INSERT .values() does not mutate the base's row list", () => {
+		// Guards the copy-on-write fix for `_values`. The row values are bound as
+		// query parameters, so isolation is checked against the bound variables
+		// rather than the rendered string.
+		const base = db.insert("user").fields(["email"]);
+		const one = base.values(["a@b.c"]);
+		const two = base.values(["x@y.z"]);
+		const oneThenMore = one.values(["c@d.e"]);
+
+		expect(base.toString()).not.toContain("VALUES");
+
+		const oneVars = boundValues(one);
+		expect(oneVars).toContain("a@b.c");
+		expect(oneVars).not.toContain("x@y.z");
+		expect(oneVars).not.toContain("c@d.e");
+
+		const twoVars = boundValues(two);
+		expect(twoVars).toContain("x@y.z");
+		expect(twoVars).not.toContain("a@b.c");
+
+		const multiVars = boundValues(oneThenMore);
+		expect(multiVars).toContain("a@b.c");
+		expect(multiVars).toContain("c@d.e");
+	});
+
+	test("live query branching stays isolated", () => {
+		const base = db.live("user");
+		const filtered = base.where(($this) => $this.age.gt(18));
+
+		expect(filtered).not.toBe(base);
+		expect(base.toString()).not.toContain("WHERE");
+		expect(filtered.toString()).toContain("WHERE");
+	});
+});


### PR DESCRIPTION
## What & why

Four robustness improvements to the query layer and packaging, from a review of the project.

### 1. Immutable query builders
Every fluent method (`.where()`, `.set()`, `.limit()`, `.fetch()`, `.return()`, …) across all eight builders (`select`, `create`, `update`, `upsert`, `delete`, `insert`, `relate`, `live`) now derives a **new** query via a shared clone-then-mutate helper (`Query.derive`) instead of mutating `this`. This wires up the previously-dead `clone()`, fixes the one genuine in-place mutation (`_addOrderBy`'s `_orderBy.push`), and makes INSERT `_values` copy-on-write.

A partially-built query can now be safely reused as the base for several divergent queries:

```ts
const base   = db.select("user");
const adults = base.where(u => u.age.gt(18)); // base is untouched
const page   = base.limit(10);                // independent of `adults`
```

> [!WARNING]
> **Technically breaking.** Code that mutated a query in place without reassigning (`const q = db.select(...); q.where(...)`) must now chain or reassign. This is exactly the footgun being removed, and we're pre-1.0 — worth a changelog line on the next release.

### 2. Identifier hardening
Field names are interpolated directly into SurrealQL (only *values* are bound as parameters). Names in `ORDER BY` / `SPLIT` / `GROUP BY` / `FETCH`, `SET` / `UNSET` / `ON DUPLICATE` keys, and INSERT columns are now escaped via the SDK's own `escapeIdent` (SurrealDB's `⟨…⟩` convention, so we escape identically to how the SDK renders table/record names). Bare identifiers are emitted unchanged; non-identifier names are quoted — e.g. `"x; DROP"` becomes `⟨x; DROP⟩`, neutralising injection through field names.

### 3. Packaging
- `"sideEffects": false` for tree-shaking.
- Broaden the `surrealdb` peerDependency to `>=2.0.0-alpha.18` (the SDK and server are versioned independently — the 2.x SDK connects to a 3.x server).

### 4. Docs
- README now documents the **SurrealDB server ≥ 3.0** requirement (not expressible as an npm constraint).

## Testing
- ✅ `tsc --noEmit`
- ✅ **537** unit tests (524 existing + 13 new — branch-isolation/copy-on-write guards and identifier-escaping incl. an injection-neutralisation case)
- ✅ **119** integration tests against a live SurrealDB 3.1.2 server
- ✅ Biome lint + format

## Reviewer notes
- The `[__ctx]` symbol is intentionally **shared** across clones — captured `.where()`/`.return()` closures compare against it to resolve `$this`/`$parent`, so giving clones a fresh id would break projections.
- No README examples relied on in-place mutation (all use fluent chaining), so docs are unaffected beyond the new Requirements section.