### PR TITLE
Type-safe graph traversal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,8 +91,16 @@ jobs:
         run: bun run test:unit
 
   integration-tests:
-    name: Integration Tests
+    name: Integration Tests (SurrealDB ${{ matrix.surrealdb_version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # `v3.1.0` is not a published release (latest stable is the 3.0.x line;
+        # 3.1.x is nightly-only and `setup-surreal` can only install release
+        # tags or `latest`), so the matrix spans the earliest 3.x stable, the
+        # newest 3.x stable, and `latest`.
+        surrealdb_version: [v3.0.0, v3.0.5, latest]
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -116,7 +124,11 @@ jobs:
       - name: Start SurrealDB
         uses: surrealdb/setup-surreal@7c103070ba4f544240cd287432ba70d6f50163a5 # v2.0.1
         with:
-          surrealdb_version: v3.0.0-beta.4
+          # NB: the workflow previously pinned `v3.0.0-beta.4`, on which graph
+          # traversal materialised via `.select()` (a subquery over a
+          # `$parent`-rooted graph path) returns empty — a beta bug fixed before
+          # the 3.0.0 stable release. The matrix above runs only stable versions.
+          surrealdb_version: ${{ matrix.surrealdb_version }}
           surrealdb_port: 8000
           surrealdb_username: root
           surrealdb_password: root

--- a/README.md
+++ b/README.md
@@ -1206,11 +1206,13 @@ console.log(ctx.variables); // Parameterized values
 
 ## Graph traversal
 
-Traverse graph edges directly inside queries. From any record — a row's `id` or a
-record-link field — `.out()` follows an edge to the far table (`->edge->target`)
-and `.in()` follows it in reverse (`<-edge<-source`). TypeScript only permits
-edges that actually connect to the current table, and the result type is inferred
-automatically.
+Traverse graph edges directly inside queries. Call `.out()` on a select row to
+follow an edge to the far table (`->edge->target`), or `.in()` to follow it in
+reverse (`<-edge<-source`). TypeScript only permits edges that actually connect
+to the current table, and the result type is inferred automatically.
+
+You can traverse from the row itself (`user.out("authored")`, rooted at the
+row's `id`) or from any record-link field (`post.author.out(...)`).
 
 ```typescript
 const user = table("user", { name: t.string() });
@@ -1233,7 +1235,7 @@ traversal compiles to a subquery:
 ```typescript
 const usersWithPosts = db.select("user").return((user) => ({
   name: user.name,
-  posts: user.id
+  posts: user
     .out("authored")              // ->authored->post
     .select()
     .return((post) => ({ title: post.title })),
@@ -1248,7 +1250,7 @@ exactly like raw SurrealQL `->authored->post`:
 
 ```typescript
 const query = db.select("user").return((user) => ({
-  postIds: user.id.out("authored"),
+  postIds: user.out("authored"),
 }));
 
 type Result = t.infer<typeof query>;
@@ -1261,7 +1263,7 @@ Steps chain, with every hop re-typed against the table it lands on:
 
 ```typescript
 db.select("user").return((user) => ({
-  tags: user.id
+  tags: user
     .out("authored")   // -> post
     .out("tagged")     // -> tag
     .select()
@@ -1275,7 +1277,7 @@ db.select("user").return((user) => ({
 ```typescript
 // Who authored this post?
 db.select("post").return((post) => ({
-  authors: post.id
+  authors: post
     .in("authored")               // <-authored<-user
     .select()
     .return((user) => ({ name: user.name })),
@@ -1289,7 +1291,7 @@ fields (such as `created` or `role`):
 
 ```typescript
 db.select("user").return((user) => ({
-  authorships: user.id.outEdge("authored").select().return((e) => ({
+  authorships: user.outEdge("authored").select().return((e) => ({
     when: e.created,
     role: e.role,
   })),
@@ -1304,7 +1306,7 @@ Filter on the edge mid-traversal with `where` — this compiles to
 
 ```typescript
 db.select("user").return((user) => ({
-  posts: user.id
+  posts: user
     .out("authored", { where: (e) => e.role.eq("author") })
     .select()
     .return((post) => ({ title: post.title })),
@@ -1317,11 +1319,48 @@ Traversals also compose inside `WHERE` to filter the outer query. `len()` and
 
 ```typescript
 // Users who have authored at least one post
-db.select("user").where((user) => user.id.out("authored").len().gt(0));
+db.select("user").where((user) => user.out("authored").len().gt(0));
 
 // Users who have authored none
-db.select("user").where((user) => user.id.out("authored").isEmpty());
+db.select("user").where((user) => user.out("authored").isEmpty());
 ```
+
+### Recursive traversal & path finding
+
+Repeat a hop with `depth` to walk several levels deep — this compiles to
+SurrealDB's recursive idiom `record.{depth}(->edge->target)` and returns the
+records reached at the deepest level. `depth` is an exact number, an inclusive
+`[min, max]` range, or `{ min?, max? }` for open-ended ranges:
+
+```typescript
+const person = table("person", { name: t.string() });
+const knows = edge("person", "knows", "person", {});
+const db = orm(new Surreal(), person, knows);
+
+// Connections between one and three hops away
+db.select("person").return((p) => ({
+  network: p.out("knows", { depth: [1, 3] }),
+}));
+// person.{1..3}(->knows->person)
+```
+
+Add `collect` to gather every unique node encountered, or `shortest` to find the
+shortest path to a target record:
+
+```typescript
+// Everyone reachable through `knows`
+db.select("person").return((p) => ({
+  reachable: p.out("knows", { collect: true }), // .{..+collect}(->knows->person)
+}));
+
+// Shortest path from one person to another (the target binds as a parameter)
+db.select("person", "alice").return((p) => ({
+  path: p.out("knows", { shortest: new RecordId("person", "dave") }),
+}));
+// person:alice.{..+shortest=$target}(->knows->person)
+```
+
+`depth` / `collect` / `shortest` compose with edge filtering (`where`) too.
 
 ### Edge adjacency metadata
 
@@ -1493,7 +1532,7 @@ This project is in active development. Planned features include:
 - [x] **Live queries** - Real-time `LIVE SELECT` subscriptions with typed notifications
 - [ ] **Runtime validation** - Validate data at runtime using schema definitions
 - [x] **Graph traversal** - Type-safe `.out()` / `.in()` edge navigation, multi-hop chaining, edge-field access, and edge filtering
-- [ ] **Advanced graph traversal** - Path finding, recursive queries, graph algorithms
+- [x] **Advanced graph traversal** - Recursive depth ranges, node collection (`collect`), and shortest-path finding (`shortest`)
 - [ ] **Performance optimizations** - Query caching, connection pooling
 - [ ] **Schema migrations** - Version control for database schemas
 - [ ] **Documentation site** - Comprehensive guides and API reference

--- a/README.md
+++ b/README.md
@@ -1204,23 +1204,132 @@ console.log(sql);           // Generated SurrealQL
 console.log(ctx.variables); // Parameterized values
 ```
 
-## Graph relationships
+## Graph traversal
 
-Surqlize provides type-safe graph traversal through the `lookup` system:
+Traverse graph edges directly inside queries. From any record — a row's `id` or a
+record-link field — `.out()` follows an edge to the far table (`->edge->target`)
+and `.in()` follows it in reverse (`<-edge<-source`). TypeScript only permits
+edges that actually connect to the current table, and the result type is inferred
+automatically.
 
 ```typescript
 const user = table("user", { name: t.string() });
 const post = table("post", { title: t.string() });
-const authored = edge("user", "authored", "post", {});
+const tag = table("tag", { label: t.string() });
+const authored = edge("user", "authored", "post", {
+  created: t.date(),
+  role: t.string(),
+});
+const tagged = edge("post", "tagged", "tag", {});
 
-const db = orm(new Surreal(), user, post, authored);
+const db = orm(new Surreal(), user, post, tag, authored, tagged);
+```
 
-// TypeScript knows which edges connect to which tables
-db.lookup.to;   // { user: ["authored"], authored: ["post"], post: [] }
-db.lookup.from; // { user: [], authored: ["user"], post: ["authored"] }
+### Materialising records with `.select()`
 
-// Use in queries for type-safe graph navigation
-// (This feature is under active development)
+Chain `.select().return()` to project the records a traversal lands on. The
+traversal compiles to a subquery:
+
+```typescript
+const usersWithPosts = db.select("user").return((user) => ({
+  name: user.name,
+  posts: user.id
+    .out("authored")              // ->authored->post
+    .select()
+    .return((post) => ({ title: post.title })),
+}));
+// posts is typed as { title: string }[]
+```
+
+### Bare traversals return record links
+
+Used directly in a projection, a traversal yields an array of record links —
+exactly like raw SurrealQL `->authored->post`:
+
+```typescript
+const query = db.select("user").return((user) => ({
+  postIds: user.id.out("authored"),
+}));
+
+type Result = t.infer<typeof query>;
+// Result: Array<{ postIds: RecordId<"post">[] }>
+```
+
+### Multi-hop chaining
+
+Steps chain, with every hop re-typed against the table it lands on:
+
+```typescript
+db.select("user").return((user) => ({
+  tags: user.id
+    .out("authored")   // -> post
+    .out("tagged")     // -> tag
+    .select()
+    .return((tag) => ({ label: tag.label })),
+}));
+// ->authored->post->tagged->tag
+```
+
+### Incoming edges
+
+```typescript
+// Who authored this post?
+db.select("post").return((post) => ({
+  authors: post.id
+    .in("authored")               // <-authored<-user
+    .select()
+    .return((user) => ({ name: user.name })),
+}));
+```
+
+### Reading edge fields
+
+`.outEdge()` / `.inEdge()` stop on the edge itself, so you can read its own
+fields (such as `created` or `role`):
+
+```typescript
+db.select("user").return((user) => ({
+  authorships: user.id.outEdge("authored").select().return((e) => ({
+    when: e.created,
+    role: e.role,
+  })),
+}));
+// ->authored
+```
+
+### Filtering traversals
+
+Filter on the edge mid-traversal with `where` — this compiles to
+`->(edge WHERE …)->target`, and the callback receives the edge's fields:
+
+```typescript
+db.select("user").return((user) => ({
+  posts: user.id
+    .out("authored", { where: (e) => e.role.eq("author") })
+    .select()
+    .return((post) => ({ title: post.title })),
+}));
+// ->(authored WHERE role = "author")->post
+```
+
+Traversals also compose inside `WHERE` to filter the outer query. `len()` and
+`isEmpty()` are the idiomatic "has any" / "has none" checks:
+
+```typescript
+// Users who have authored at least one post
+db.select("user").where((user) => user.id.out("authored").len().gt(0));
+
+// Users who have authored none
+db.select("user").where((user) => user.id.out("authored").isEmpty());
+```
+
+### Edge adjacency metadata
+
+The `lookup` maps expose which edges connect which tables at runtime:
+
+```typescript
+db.lookup.to;   // { user: ["authored"], post: ["tagged"], tag: [], ... }
+db.lookup.from; // { post: ["authored"], tag: ["tagged"], user: [], ... }
 ```
 
 ## Complex example
@@ -1383,6 +1492,7 @@ This project is in active development. Planned features include:
 - [x] **Multi-session support** - Multiple sessions over a single connection
 - [x] **Live queries** - Real-time `LIVE SELECT` subscriptions with typed notifications
 - [ ] **Runtime validation** - Validate data at runtime using schema definitions
+- [x] **Graph traversal** - Type-safe `.out()` / `.in()` edge navigation, multi-hop chaining, edge-field access, and edge filtering
 - [ ] **Advanced graph traversal** - Path finding, recursive queries, graph algorithms
 - [ ] **Performance optimizations** - Query caching, connection pooling
 - [ ] **Schema migrations** - Version control for database schemas

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -12,6 +12,7 @@ const functions = {
 	any: typeFunctions.any.functions,
 	array: typeFunctions.array.functions,
 	date: typeFunctions.date.functions,
+	graph: typeFunctions.graph.functions,
 	number: typeFunctions.number.functions,
 	option: typeFunctions.option.functions,
 	record: typeFunctions.record.functions,
@@ -22,6 +23,7 @@ interface BaseFunctions {
 	any: typeFunctions.any.Functions;
 	array: typeFunctions.array.Functions;
 	date: typeFunctions.date.Functions;
+	graph: typeFunctions.graph.Functions;
 	number: typeFunctions.number.Functions;
 	option: typeFunctions.option.Functions;
 	record: typeFunctions.record.Functions;

--- a/src/functions/types/graph.ts
+++ b/src/functions/types/graph.ts
@@ -7,12 +7,24 @@ import type {
 	ToOf,
 	TraverseOpts,
 } from "../../schema/traversal";
-import type { GraphType, RecordType } from "../../types";
-import { __ctx, type Workable, type WorkableContext } from "../../utils";
+import { type BoolType, type GraphType, type NumberType, t } from "../../types";
+import {
+	__ctx,
+	type IntoWorkable,
+	type Workable,
+	type WorkableContext,
+} from "../../utils";
 import type { Actionable } from "../../utils/actionable";
-import { edgeFilter, traverse } from "../utils";
+import { comparingFilter } from "../filters";
+import { databaseFunction, edgeFilter, traverse } from "../utils";
 
-/** Read an edge schema by its registered name. */
+/**
+ * Functions available on a graph-traversal step (a {@link GraphType} workable).
+ * Mirrors the record traversal verbs so steps chain indefinitely
+ * (`user.out("authored").in("commented")`), plus `.select()` to materialise the
+ * landed records into full rows or a projection.
+ */
+
 function edgeSchema<C extends WorkableContext>(
 	workable: Workable<C>,
 	edge: string,
@@ -24,7 +36,7 @@ export const functions = {
 	select<
 		C extends WorkableContext,
 		Tb extends keyof C["orm"]["tables"] & string,
-	>(this: Workable<C, RecordType<Tb>>) {
+	>(this: Workable<C, GraphType<Tb>>) {
 		return this[__ctx].orm.select(this);
 	},
 
@@ -33,7 +45,7 @@ export const functions = {
 		Tb extends keyof C["orm"]["tables"] & string,
 		Edge extends OutgoingEdges<C, Tb>,
 	>(
-		this: Workable<C, RecordType<Tb>>,
+		this: Workable<C, GraphType<Tb>>,
 		edge: Edge,
 		opts?: TraverseOpts<C, Edge>,
 	) {
@@ -53,7 +65,7 @@ export const functions = {
 		Tb extends keyof C["orm"]["tables"] & string,
 		Edge extends IncomingEdges<C, Tb>,
 	>(
-		this: Workable<C, RecordType<Tb>>,
+		this: Workable<C, GraphType<Tb>>,
 		edge: Edge,
 		opts?: TraverseOpts<C, Edge>,
 	) {
@@ -73,7 +85,7 @@ export const functions = {
 		Tb extends keyof C["orm"]["tables"] & string,
 		Edge extends OutgoingEdges<C, Tb>,
 	>(
-		this: Workable<C, RecordType<Tb>>,
+		this: Workable<C, GraphType<Tb>>,
 		edge: Edge,
 		opts?: TraverseOpts<C, Edge>,
 	) {
@@ -96,7 +108,7 @@ export const functions = {
 		Tb extends keyof C["orm"]["tables"] & string,
 		Edge extends IncomingEdges<C, Tb>,
 	>(
-		this: Workable<C, RecordType<Tb>>,
+		this: Workable<C, GraphType<Tb>>,
 		edge: Edge,
 		opts?: TraverseOpts<C, Edge>,
 	) {
@@ -110,55 +122,94 @@ export const functions = {
 			GraphType<Edge>
 		>;
 	},
+
+	// Array predicates over the traversal result, for use in WHERE / projections.
+	// `array::len(->edge->target) > 0` is the idiomatic "has any" check.
+	len<C extends WorkableContext, Tb extends keyof C["orm"]["tables"] & string>(
+		this: Workable<C, GraphType<Tb>>,
+	) {
+		return databaseFunction(this[__ctx], t.number(), "array::len", this);
+	},
+
+	isEmpty<
+		C extends WorkableContext,
+		Tb extends keyof C["orm"]["tables"] & string,
+	>(this: Workable<C, GraphType<Tb>>) {
+		return databaseFunction(this[__ctx], t.bool(), "array::is_empty", this);
+	},
+
+	contains<
+		C extends WorkableContext,
+		Tb extends keyof C["orm"]["tables"] & string,
+	>(this: Workable<C, GraphType<Tb>>, v: IntoWorkable<C>) {
+		// Widen `this` so the membership value is an element, not the array itself.
+		return comparingFilter(this[__ctx], "CONTAINS", this as Workable<C>, v);
+	},
 } satisfies Functions;
 
 export type Functions = {
 	select<
 		C extends WorkableContext,
 		Tb extends keyof C["orm"]["tables"] & string,
-	>(this: Workable<C, RecordType<Tb>>): SelectQuery<C["orm"], C, Tb>;
+	>(this: Workable<C, GraphType<Tb>>): SelectQuery<C["orm"], C, Tb>;
 
-	/** Traverse outgoing through `edge` to the far node: `->edge->target`. */
 	out<
 		C extends WorkableContext,
 		Tb extends keyof C["orm"]["tables"] & string,
 		Edge extends OutgoingEdges<C, Tb>,
 	>(
-		this: Workable<C, RecordType<Tb>>,
+		this: Workable<C, GraphType<Tb>>,
 		edge: Edge,
 		opts?: TraverseOpts<C, Edge>,
 	): Actionable<C, GraphType<ToOf<C, Edge>>>;
 
-	/** Traverse incoming through `edge` to the far node: `<-edge<-source`. */
 	in<
 		C extends WorkableContext,
 		Tb extends keyof C["orm"]["tables"] & string,
 		Edge extends IncomingEdges<C, Tb>,
 	>(
-		this: Workable<C, RecordType<Tb>>,
+		this: Workable<C, GraphType<Tb>>,
 		edge: Edge,
 		opts?: TraverseOpts<C, Edge>,
 	): Actionable<C, GraphType<FromOf<C, Edge>>>;
 
-	/** Traverse outgoing and stop on the edge itself: `->edge`. */
 	outEdge<
 		C extends WorkableContext,
 		Tb extends keyof C["orm"]["tables"] & string,
 		Edge extends OutgoingEdges<C, Tb>,
 	>(
-		this: Workable<C, RecordType<Tb>>,
+		this: Workable<C, GraphType<Tb>>,
 		edge: Edge,
 		opts?: TraverseOpts<C, Edge>,
 	): Actionable<C, GraphType<Edge>>;
 
-	/** Traverse incoming and stop on the edge itself: `<-edge`. */
 	inEdge<
 		C extends WorkableContext,
 		Tb extends keyof C["orm"]["tables"] & string,
 		Edge extends IncomingEdges<C, Tb>,
 	>(
-		this: Workable<C, RecordType<Tb>>,
+		this: Workable<C, GraphType<Tb>>,
 		edge: Edge,
 		opts?: TraverseOpts<C, Edge>,
 	): Actionable<C, GraphType<Edge>>;
+
+	/** Number of records the traversal lands on (`array::len`). */
+	len<C extends WorkableContext, Tb extends keyof C["orm"]["tables"] & string>(
+		this: Workable<C, GraphType<Tb>>,
+	): Actionable<C, NumberType>;
+
+	/** Whether the traversal lands on no records (`array::is_empty`). */
+	isEmpty<
+		C extends WorkableContext,
+		Tb extends keyof C["orm"]["tables"] & string,
+	>(this: Workable<C, GraphType<Tb>>): Actionable<C, BoolType>;
+
+	/** Whether the traversal result contains a given record (`CONTAINS`). */
+	contains<
+		C extends WorkableContext,
+		Tb extends keyof C["orm"]["tables"] & string,
+	>(
+		this: Workable<C, GraphType<Tb>>,
+		v: IntoWorkable<C>,
+	): Actionable<C, BoolType>;
 };

--- a/src/functions/types/graph.ts
+++ b/src/functions/types/graph.ts
@@ -4,6 +4,7 @@ import type {
 	FromOf,
 	IncomingEdges,
 	OutgoingEdges,
+	RecurseOpts,
 	ToOf,
 	TraverseOpts,
 } from "../../schema/traversal";
@@ -16,7 +17,7 @@ import {
 } from "../../utils";
 import type { Actionable } from "../../utils/actionable";
 import { comparingFilter } from "../filters";
-import { databaseFunction, edgeFilter, traverse } from "../utils";
+import { databaseFunction, edgeFilter, recursionOf, traverse } from "../utils";
 
 /**
  * Functions available on a graph-traversal step (a {@link GraphType} workable).
@@ -47,7 +48,7 @@ export const functions = {
 	>(
 		this: Workable<C, GraphType<Tb>>,
 		edge: Edge,
-		opts?: TraverseOpts<C, Edge>,
+		opts?: TraverseOpts<C, Edge> & RecurseOpts<C, Edge>,
 	) {
 		const schema = edgeSchema(this, edge);
 		const where = edgeFilter(this[__ctx], schema.schema, opts?.where);
@@ -57,6 +58,7 @@ export const functions = {
 			edge,
 			schema.to,
 			where,
+			recursionOf(opts),
 		) as unknown as Actionable<C, GraphType<ToOf<C, Edge>>>;
 	},
 
@@ -67,7 +69,7 @@ export const functions = {
 	>(
 		this: Workable<C, GraphType<Tb>>,
 		edge: Edge,
-		opts?: TraverseOpts<C, Edge>,
+		opts?: TraverseOpts<C, Edge> & RecurseOpts<C, Edge>,
 	) {
 		const schema = edgeSchema(this, edge);
 		const where = edgeFilter(this[__ctx], schema.schema, opts?.where);
@@ -77,6 +79,7 @@ export const functions = {
 			edge,
 			schema.from,
 			where,
+			recursionOf(opts),
 		) as unknown as Actionable<C, GraphType<FromOf<C, Edge>>>;
 	},
 
@@ -160,7 +163,7 @@ export type Functions = {
 	>(
 		this: Workable<C, GraphType<Tb>>,
 		edge: Edge,
-		opts?: TraverseOpts<C, Edge>,
+		opts?: TraverseOpts<C, Edge> & RecurseOpts<C, Edge>,
 	): Actionable<C, GraphType<ToOf<C, Edge>>>;
 
 	in<
@@ -170,7 +173,7 @@ export type Functions = {
 	>(
 		this: Workable<C, GraphType<Tb>>,
 		edge: Edge,
-		opts?: TraverseOpts<C, Edge>,
+		opts?: TraverseOpts<C, Edge> & RecurseOpts<C, Edge>,
 	): Actionable<C, GraphType<FromOf<C, Edge>>>;
 
 	outEdge<

--- a/src/functions/types/index.ts
+++ b/src/functions/types/index.ts
@@ -1,6 +1,7 @@
 export * as any from "./any";
 export * as array from "./array";
 export * as date from "./date";
+export * as graph from "./graph";
 export * as number from "./number";
 export * as option from "./option";
 export * as record from "./record";

--- a/src/functions/types/record.ts
+++ b/src/functions/types/record.ts
@@ -4,13 +4,14 @@ import type {
 	FromOf,
 	IncomingEdges,
 	OutgoingEdges,
+	RecurseOpts,
 	ToOf,
 	TraverseOpts,
 } from "../../schema/traversal";
 import type { GraphType, RecordType } from "../../types";
 import { __ctx, type Workable, type WorkableContext } from "../../utils";
 import type { Actionable } from "../../utils/actionable";
-import { edgeFilter, traverse } from "../utils";
+import { edgeFilter, recursionOf, traverse } from "../utils";
 
 /** Read an edge schema by its registered name. */
 function edgeSchema<C extends WorkableContext>(
@@ -35,7 +36,7 @@ export const functions = {
 	>(
 		this: Workable<C, RecordType<Tb>>,
 		edge: Edge,
-		opts?: TraverseOpts<C, Edge>,
+		opts?: TraverseOpts<C, Edge> & RecurseOpts<C, Edge>,
 	) {
 		const schema = edgeSchema(this, edge);
 		const where = edgeFilter(this[__ctx], schema.schema, opts?.where);
@@ -45,6 +46,7 @@ export const functions = {
 			edge,
 			schema.to,
 			where,
+			recursionOf(opts),
 		) as unknown as Actionable<C, GraphType<ToOf<C, Edge>>>;
 	},
 
@@ -55,7 +57,7 @@ export const functions = {
 	>(
 		this: Workable<C, RecordType<Tb>>,
 		edge: Edge,
-		opts?: TraverseOpts<C, Edge>,
+		opts?: TraverseOpts<C, Edge> & RecurseOpts<C, Edge>,
 	) {
 		const schema = edgeSchema(this, edge);
 		const where = edgeFilter(this[__ctx], schema.schema, opts?.where);
@@ -65,6 +67,7 @@ export const functions = {
 			edge,
 			schema.from,
 			where,
+			recursionOf(opts),
 		) as unknown as Actionable<C, GraphType<FromOf<C, Edge>>>;
 	},
 
@@ -118,7 +121,10 @@ export type Functions = {
 		Tb extends keyof C["orm"]["tables"] & string,
 	>(this: Workable<C, RecordType<Tb>>): SelectQuery<C["orm"], C, Tb>;
 
-	/** Traverse outgoing through `edge` to the far node: `->edge->target`. */
+	/**
+	 * Traverse outgoing through `edge` to the far node: `->edge->target`. Pass
+	 * `depth` / `collect` / `shortest` to recurse (`head.{depth}(->edge->target)`).
+	 */
 	out<
 		C extends WorkableContext,
 		Tb extends keyof C["orm"]["tables"] & string,
@@ -126,10 +132,13 @@ export type Functions = {
 	>(
 		this: Workable<C, RecordType<Tb>>,
 		edge: Edge,
-		opts?: TraverseOpts<C, Edge>,
+		opts?: TraverseOpts<C, Edge> & RecurseOpts<C, Edge>,
 	): Actionable<C, GraphType<ToOf<C, Edge>>>;
 
-	/** Traverse incoming through `edge` to the far node: `<-edge<-source`. */
+	/**
+	 * Traverse incoming through `edge` to the far node: `<-edge<-source`. Pass
+	 * `depth` / `collect` / `shortest` to recurse.
+	 */
 	in<
 		C extends WorkableContext,
 		Tb extends keyof C["orm"]["tables"] & string,
@@ -137,7 +146,7 @@ export type Functions = {
 	>(
 		this: Workable<C, RecordType<Tb>>,
 		edge: Edge,
-		opts?: TraverseOpts<C, Edge>,
+		opts?: TraverseOpts<C, Edge> & RecurseOpts<C, Edge>,
 	): Actionable<C, GraphType<FromOf<C, Edge>>>;
 
 	/** Traverse outgoing and stop on the edge itself: `->edge`. */

--- a/src/functions/utils.ts
+++ b/src/functions/utils.ts
@@ -1,9 +1,12 @@
+import type { RecordId } from "surrealdb";
+import type { RecurseDepth } from "../schema/traversal";
 import { type AbstractType, GraphType, type ObjectType } from "../types";
 import {
 	__ctx,
 	__display,
 	__type,
 	type DisplayContext,
+	isWorkable,
 	type Workable,
 	type WorkableContext,
 } from "../utils";
@@ -26,12 +29,49 @@ export function databaseFunction<
 /** Direction + landing of a single graph-traversal step. */
 export type TraversalKind = "out" | "in" | "outEdge" | "inEdge";
 
+/** Recursion spec for a recursive / path-finding traversal step. */
+export type Recursion<C extends WorkableContext> = {
+	depth?: RecurseDepth;
+	collect?: boolean;
+	shortest?: RecordId | Workable<C>;
+};
+
+/** Render a {@link RecurseDepth} as the brace range, e.g. `1..3`, `..3`, `..`. */
+function formatDepth(depth: RecurseDepth | undefined): string {
+	if (depth === undefined) return "..";
+	if (typeof depth === "number") return String(depth);
+	if (Array.isArray(depth)) return `${depth[0]}..${depth[1]}`;
+	const { min, max } = depth as { min?: number; max?: number };
+	return `${min ?? ""}..${max ?? ""}`;
+}
+
+/** The full brace expression for a recursion, e.g. `.{1..3}`, `.{..+collect}`. */
+function recursionBraces<C extends WorkableContext>(
+	ctx: DisplayContext,
+	recursion: Recursion<C>,
+): string {
+	let modifier = "";
+	if (recursion.shortest !== undefined) {
+		const tgt = isWorkable(recursion.shortest)
+			? recursion.shortest[__display](ctx)
+			: ctx.var(recursion.shortest);
+		modifier = `+shortest=${tgt}`;
+	} else if (recursion.collect) {
+		modifier = "+collect";
+	}
+	return `.{${formatDepth(recursion.depth)}${modifier}}`;
+}
+
 /**
  * Build a graph-traversal expression by appending an edge segment to `parent`'s
  * idiom. `out`/`in` traverse through the edge to the far node
  * (`->edge->target` / `<-edge<-target`); `outEdge`/`inEdge` stop on the edge
  * itself (`->edge` / `<-edge`). An optional `whereSql` renders an edge filter as
  * `->(edge WHERE …)->target`.
+ *
+ * When `recursion` is given, the hop is wrapped in SurrealDB's recursive idiom
+ * `head.{depth}(->edge->target)`, optionally with a `+collect` or
+ * `+shortest=target` modifier for path finding.
  *
  * The result is a {@link GraphType} workable carrying the table it lands on, so
  * it chains (`.out()`/`.in()`), materialises (`.select()`), or — used bare —
@@ -43,6 +83,7 @@ export function traverse<C extends WorkableContext, Target extends string>(
 	edge: string,
 	target: Target,
 	whereSql?: (ctx: DisplayContext) => string,
+	recursion?: Recursion<C>,
 ): Actionable<C, GraphType<Target>> {
 	const arrow = kind === "out" || kind === "outEdge" ? "->" : "<-";
 	const landsOnEdge = kind === "outEdge" || kind === "inEdge";
@@ -54,9 +95,33 @@ export function traverse<C extends WorkableContext, Target extends string>(
 			const head = parent[__display](ctx);
 			const edgeFrag = whereSql ? `(${edge} WHERE ${whereSql(ctx)})` : edge;
 			const tail = landsOnEdge ? "" : `${arrow}${target}`;
-			return `${head}${arrow}${edgeFrag}${tail}`;
+			const body = `${arrow}${edgeFrag}${tail}`;
+
+			return recursion
+				? `${head}${recursionBraces(ctx, recursion)}(${body})`
+				: `${head}${body}`;
 		},
 	});
+}
+
+/**
+ * Distil the recursion-related options of a traversal step into a
+ * {@link Recursion} spec, or `undefined` when none are set (a plain hop).
+ */
+export function recursionOf<C extends WorkableContext>(
+	opts:
+		| {
+				depth?: RecurseDepth;
+				collect?: boolean;
+				shortest?: RecordId | Workable<C>;
+		  }
+		| undefined,
+): Recursion<C> | undefined {
+	if (!opts) return undefined;
+	const { depth, collect, shortest } = opts;
+	if (depth === undefined && !collect && shortest === undefined)
+		return undefined;
+	return { depth, collect, shortest };
 }
 
 /**

--- a/src/functions/utils.ts
+++ b/src/functions/utils.ts
@@ -1,8 +1,9 @@
-import type { AbstractType } from "../types";
+import { type AbstractType, GraphType, type ObjectType } from "../types";
 import {
 	__ctx,
 	__display,
 	__type,
+	type DisplayContext,
 	type Workable,
 	type WorkableContext,
 } from "../utils";
@@ -20,4 +21,82 @@ export function databaseFunction<
 			return `${fn}(${vars})`;
 		},
 	});
+}
+
+/** Direction + landing of a single graph-traversal step. */
+export type TraversalKind = "out" | "in" | "outEdge" | "inEdge";
+
+/**
+ * Build a graph-traversal expression by appending an edge segment to `parent`'s
+ * idiom. `out`/`in` traverse through the edge to the far node
+ * (`->edge->target` / `<-edge<-target`); `outEdge`/`inEdge` stop on the edge
+ * itself (`->edge` / `<-edge`). An optional `whereSql` renders an edge filter as
+ * `->(edge WHERE …)->target`.
+ *
+ * The result is a {@link GraphType} workable carrying the table it lands on, so
+ * it chains (`.out()`/`.in()`), materialises (`.select()`), or — used bare —
+ * infers as an array of record links.
+ */
+export function traverse<C extends WorkableContext, Target extends string>(
+	parent: Workable<C>,
+	kind: TraversalKind,
+	edge: string,
+	target: Target,
+	whereSql?: (ctx: DisplayContext) => string,
+): Actionable<C, GraphType<Target>> {
+	const arrow = kind === "out" || kind === "outEdge" ? "->" : "<-";
+	const landsOnEdge = kind === "outEdge" || kind === "inEdge";
+
+	return actionable({
+		[__ctx]: parent[__ctx],
+		[__type]: new GraphType(target),
+		[__display](ctx: DisplayContext) {
+			const head = parent[__display](ctx);
+			const edgeFrag = whereSql ? `(${edge} WHERE ${whereSql(ctx)})` : edge;
+			const tail = landsOnEdge ? "" : `${arrow}${target}`;
+			return `${head}${arrow}${edgeFrag}${tail}`;
+		},
+	});
+}
+
+/**
+ * A proxy over an edge's fields that renders each as a bare identifier
+ * (`role`, `created`) rather than `$this.role`. Bare names are what SurrealDB
+ * expects inside a graph filter, e.g. `->(authored WHERE role = $v)->post`.
+ */
+function edgeFieldProxy<C extends WorkableContext>(
+	ctx: C,
+	schema: ObjectType,
+): Actionable<C, ObjectType> {
+	return new Proxy(
+		{},
+		{
+			get(_target, prop) {
+				const [type] = schema.get(prop as string);
+				return actionable({
+					[__ctx]: ctx,
+					[__type]: type,
+					[__display]: () => prop as string,
+				});
+			},
+		},
+	) as Actionable<C, ObjectType>;
+}
+
+/**
+ * Compile an optional edge-filter callback into a renderer for the `WHERE`
+ * clause inside a graph traversal, or `undefined` when no filter is given. The
+ * callback receives the edge's fields as bare identifiers; the returned
+ * function renders the predicate against a display context, so parameters bind
+ * into the shared variable store.
+ */
+export function edgeFilter<C extends WorkableContext>(
+	ctx: C,
+	schema: ObjectType,
+	// biome-ignore lint/suspicious/noExplicitAny: the edge-field shape is enforced at each call's type signature
+	cb: ((edge: any) => Workable<C>) | undefined,
+): ((ctx: DisplayContext) => string) | undefined {
+	if (!cb) return undefined;
+	const predicate = cb(edgeFieldProxy(ctx, schema));
+	return (dctx) => predicate[__display](dctx);
 }

--- a/src/query/select.ts
+++ b/src/query/select.ts
@@ -3,6 +3,7 @@ import type { Orm } from "../schema/orm.ts";
 import {
 	type AbstractType,
 	ArrayType,
+	type GraphType,
 	ObjectType,
 	type ObjectTypeInner,
 	OptionType,
@@ -141,9 +142,12 @@ export class SelectQuery<
 	private _fetchResolvedType?: AbstractType;
 	private _timeout?: string;
 	private tb: T;
-	private subject: T | RecordId<T> | Workable<C, RecordType<T>>;
+	private subject: T | RecordId<T> | Workable<C, RecordType<T> | GraphType<T>>;
 
-	constructor(orm: O, subject: T | RecordId<T> | Workable<C, RecordType<T>>) {
+	constructor(
+		orm: O,
+		subject: T | RecordId<T> | Workable<C, RecordType<T> | GraphType<T>>,
+	) {
 		super();
 		this[__ctx] = {
 			orm,

--- a/src/query/select.ts
+++ b/src/query/select.ts
@@ -1,5 +1,6 @@
 import { type RecordId, Table } from "surrealdb";
 import type { Orm } from "../schema/orm.ts";
+import type { RowTraversal } from "../schema/traversal.ts";
 import {
 	type AbstractType,
 	ArrayType,
@@ -17,6 +18,7 @@ import {
 	type InheritableIntoType,
 	inheritableIntoWorkable,
 } from "../utils/inheritable.ts";
+import { traversableRow } from "../utils/traversal.ts";
 import {
 	__ctx,
 	__display,
@@ -181,17 +183,30 @@ export class SelectQuery<
 		return t.array(this.entry);
 	}
 
-	return<
-		P extends Inheritable<C>,
-		R extends InheritableIntoType<C, P> = InheritableIntoType<C, P>,
-	>(cb: (tb: Actionable<C, E>) => P): SelectQuery<O, C, T, R> {
-		const tb = actionable({
+	/**
+	 * Build the row actionable handed to `.return()` / `.where()` / `.orderBy()`
+	 * callbacks: it renders as `$this` (or `$parent` when nested) and carries the
+	 * row's id, so traversal verbs called directly on it root at `<row>.id`.
+	 */
+	private rowActionable<S extends AbstractType>(type: S): Actionable<C, S> {
+		const base = actionable({
 			[__ctx]: this[__ctx],
-			[__type]: this.entry,
+			[__type]: type,
 			[__display]: ({ contextId }) => {
 				return contextId === this[__ctx].id ? "$this" : "$parent";
 			},
-		}) as Actionable<C, E>;
+		}) as Actionable<C, S>;
+		return traversableRow(base, this[__ctx].orm.tables[this.tb]!.schema.schema);
+	}
+
+	return<
+		P extends Inheritable<C>,
+		R extends InheritableIntoType<C, P> = InheritableIntoType<C, P>,
+	>(
+		cb: (tb: Actionable<C, E> & RowTraversal<C, T>) => P,
+	): SelectQuery<O, C, T, R> {
+		const tb = this.rowActionable(this.entry) as Actionable<C, E> &
+			RowTraversal<C, T>;
 
 		const predicable = cb(tb);
 		const workable = inheritableIntoWorkable<C, P>(
@@ -204,14 +219,14 @@ export class SelectQuery<
 		}) as unknown as SelectQuery<O, C, T, R>;
 	}
 
-	where(cb: (tb: Actionable<C, O["tables"][T]["schema"]>) => Workable<C>) {
-		const tb = actionable({
-			[__ctx]: this[__ctx],
-			[__type]: this[__ctx].orm.tables[this.tb]!.schema,
-			[__display]: ({ contextId }) => {
-				return contextId === this[__ctx].id ? "$this" : "$parent";
-			},
-		}) as Actionable<C, O["tables"][T]["schema"]>;
+	where(
+		cb: (
+			tb: Actionable<C, O["tables"][T]["schema"]> & RowTraversal<C, T>,
+		) => Workable<C>,
+	) {
+		const tb = this.rowActionable(
+			this[__ctx].orm.tables[this.tb]!.schema,
+		) as Actionable<C, O["tables"][T]["schema"]> & RowTraversal<C, T>;
 
 		const filter = sanitizeWorkable(cb(tb));
 		return this.derive((next) => {
@@ -232,7 +247,9 @@ export class SelectQuery<
 	}
 
 	private _addOrderBy(
-		field: FieldKeys<O, T> | ((record: Actionable<C, E>) => Workable<C>),
+		field:
+			| FieldKeys<O, T>
+			| ((record: Actionable<C, E> & RowTraversal<C, T>) => Workable<C>),
 		direction?: "ASC" | "DESC",
 		opts?: { collate?: boolean; numeric?: boolean },
 	): this {
@@ -242,13 +259,8 @@ export class SelectQuery<
 				: {
 						field: sanitizeWorkable(
 							field(
-								actionable({
-									[__ctx]: this[__ctx],
-									[__type]: this.entry,
-									[__display]: ({ contextId }) => {
-										return contextId === this[__ctx].id ? "$this" : "$parent";
-									},
-								}) as Actionable<C, E>,
+								this.rowActionable(this.entry) as Actionable<C, E> &
+									RowTraversal<C, T>,
 							),
 						),
 						direction,
@@ -260,21 +272,27 @@ export class SelectQuery<
 	}
 
 	orderBy(
-		field: FieldKeys<O, T> | ((record: Actionable<C, E>) => Workable<C>),
+		field:
+			| FieldKeys<O, T>
+			| ((record: Actionable<C, E> & RowTraversal<C, T>) => Workable<C>),
 		direction?: "ASC" | "DESC",
 	): this {
 		return this._addOrderBy(field, direction);
 	}
 
 	orderByNumeric(
-		field: FieldKeys<O, T> | ((record: Actionable<C, E>) => Workable<C>),
+		field:
+			| FieldKeys<O, T>
+			| ((record: Actionable<C, E> & RowTraversal<C, T>) => Workable<C>),
 		direction?: "ASC" | "DESC",
 	): this {
 		return this._addOrderBy(field, direction, { numeric: true });
 	}
 
 	orderByCollate(
-		field: FieldKeys<O, T> | ((record: Actionable<C, E>) => Workable<C>),
+		field:
+			| FieldKeys<O, T>
+			| ((record: Actionable<C, E> & RowTraversal<C, T>) => Workable<C>),
 		direction?: "ASC" | "DESC",
 	): this {
 		return this._addOrderBy(field, direction, { collate: true });

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -3,3 +3,4 @@ export * from "./edge";
 export * from "./function";
 export * from "./orm";
 export * from "./table";
+export * from "./traversal";

--- a/src/schema/orm.ts
+++ b/src/schema/orm.ts
@@ -13,7 +13,7 @@ import { SelectQuery } from "../query/select";
 import type { Transaction } from "../query/transaction";
 import { UpdateQuery } from "../query/update";
 import { UpsertQuery } from "../query/upsert";
-import type { AbstractType, ArrayType, RecordType } from "../types";
+import type { AbstractType, ArrayType, GraphType, RecordType } from "../types";
 import { isWorkable, type Workable, type WorkableContext } from "../utils";
 import type { ApiEndpointSchema } from "./api";
 import { EdgeSchema } from "./edge";
@@ -98,6 +98,11 @@ export class Orm<T extends AnyTable[] = AnyTable[]> {
 		C extends WorkableContext<this>,
 		Tb extends keyof this["tables"] & string,
 	>(rid: Workable<C, RecordType<Tb>>): SelectQuery<this, C, Tb>;
+	// Graph-traversal step (e.g. `user.out("authored")`)
+	select<
+		C extends WorkableContext<this>,
+		Tb extends keyof this["tables"] & string,
+	>(step: Workable<C, GraphType<Tb>>): SelectQuery<this, C, Tb>;
 	select<
 		C extends WorkableContext<this>,
 		Tb extends keyof this["tables"] & string,
@@ -107,7 +112,10 @@ export class Orm<T extends AnyTable[] = AnyTable[]> {
 	select<
 		C extends WorkableContext<this>,
 		Tb extends keyof this["tables"] & string,
-	>(tb: Tb | RecordId<Tb> | Workable<C, RecordType<Tb>>, id?: RecordIdValue) {
+	>(
+		tb: Tb | RecordId<Tb> | Workable<C, RecordType<Tb> | GraphType<Tb>>,
+		id?: RecordIdValue,
+	) {
 		if (tb instanceof RecordId) return new SelectQuery(this, tb);
 		if (isWorkable(tb))
 			return new SelectQuery(this, tb as Workable<C, RecordType<Tb>>);

--- a/src/schema/traversal.ts
+++ b/src/schema/traversal.ts
@@ -1,3 +1,5 @@
+import type { RecordId } from "surrealdb";
+import type { GraphType, RecordType } from "../types";
 import type { Workable, WorkableContext } from "../utils";
 import type { Actionable } from "../utils/actionable";
 import type { EdgeSchema } from "./edge";
@@ -37,6 +39,55 @@ export type EdgeFieldsOf<
  */
 export type TraverseOpts<C extends WorkableContext, Edge extends string> = {
 	where?: (edge: Actionable<C, EdgeFieldsOf<C, Edge>>) => Workable<C>;
+};
+
+/**
+ * A recursion depth: an exact number of hops (`{n}`), an inclusive `[min, max]`
+ * range (`{min..max}`), or `{ min?, max? }` for open-ended ranges (`{min..}`,
+ * `{..max}`, `{..}`). Omitting it with `collect`/`shortest` defaults to `{..}`.
+ */
+export type RecurseDepth =
+	| number
+	| readonly [number, number]
+	| { min?: number; max?: number };
+
+/**
+ * Recursive / path-finding options for `.out()` / `.in()`. Triggering any of
+ * these compiles to SurrealDB's recursive idiom `record.{depth}(->edge->target)`:
+ *
+ * - `depth` — how many times to repeat the hop; returns the deepest records.
+ * - `collect` — gather every unique node encountered (`{depth+collect}`).
+ * - `shortest` — the shortest path to a target record (`{depth+shortest=target}`).
+ */
+export type RecurseOpts<C extends WorkableContext, Edge extends string> = {
+	depth?: RecurseDepth;
+	collect?: boolean;
+	shortest?: RecordId<ToOf<C, Edge>> | Workable<C, RecordType<ToOf<C, Edge>>>;
+};
+
+/**
+ * Row-level traversal sugar: the traversal verbs callable directly on a select
+ * row (`user.out("authored")`), rooted at the row's `id`. On edge tables the
+ * runtime keeps `in` / `out` resolving as record-link fields (a verb is only
+ * dispatched when the table has no field of that name).
+ */
+export type RowTraversal<C extends WorkableContext, T extends string> = {
+	out<Edge extends OutgoingEdges<C, T>>(
+		edge: Edge,
+		opts?: TraverseOpts<C, Edge> & RecurseOpts<C, Edge>,
+	): Actionable<C, GraphType<ToOf<C, Edge>>>;
+	in<Edge extends IncomingEdges<C, T>>(
+		edge: Edge,
+		opts?: TraverseOpts<C, Edge> & RecurseOpts<C, Edge>,
+	): Actionable<C, GraphType<FromOf<C, Edge>>>;
+	outEdge<Edge extends OutgoingEdges<C, T>>(
+		edge: Edge,
+		opts?: TraverseOpts<C, Edge>,
+	): Actionable<C, GraphType<Edge>>;
+	inEdge<Edge extends IncomingEdges<C, T>>(
+		edge: Edge,
+		opts?: TraverseOpts<C, Edge>,
+	): Actionable<C, GraphType<Edge>>;
 };
 
 /** The source table of an edge — where `<-edge<-` lands. */

--- a/src/schema/traversal.ts
+++ b/src/schema/traversal.ts
@@ -1,0 +1,102 @@
+import type { Workable, WorkableContext } from "../utils";
+import type { Actionable } from "../utils/actionable";
+import type { EdgeSchema } from "./edge";
+
+/**
+ * The target table of an edge — where `->edge->` lands. Resolved directly from
+ * the {@link EdgeSchema} generics registered on the ORM, so a single hop is
+ * unambiguous (surqlize edges are strictly `from → via → to`).
+ */
+export type ToOf<
+	C extends WorkableContext,
+	Edge extends string,
+> = Edge extends keyof C["orm"]["tables"]
+	? C["orm"]["tables"][Edge] extends EdgeSchema<
+			infer _From,
+			infer _Via,
+			infer To,
+			// biome-ignore lint/suspicious/noExplicitAny: matching the edge's field generic
+			any
+		>
+		? To
+		: never
+	: never;
+
+/** The edge's own schema (an `ObjectType` of its fields), as actionable. */
+export type EdgeFieldsOf<
+	C extends WorkableContext,
+	Edge extends string,
+> = Edge extends keyof C["orm"]["tables"]
+	? C["orm"]["tables"][Edge]["schema"]
+	: never;
+
+/**
+ * Options for a traversal step. `where` filters on the edge mid-traversal,
+ * compiling to `->(edge WHERE …)->target`; its callback receives the edge's
+ * fields (e.g. `created`, `role`).
+ */
+export type TraverseOpts<C extends WorkableContext, Edge extends string> = {
+	where?: (edge: Actionable<C, EdgeFieldsOf<C, Edge>>) => Workable<C>;
+};
+
+/** The source table of an edge — where `<-edge<-` lands. */
+export type FromOf<
+	C extends WorkableContext,
+	Edge extends string,
+> = Edge extends keyof C["orm"]["tables"]
+	? C["orm"]["tables"][Edge] extends EdgeSchema<
+			infer From,
+			infer _Via,
+			infer _To,
+			// biome-ignore lint/suspicious/noExplicitAny: matching the edge's field generic
+			any
+		>
+		? From
+		: never
+	: never;
+
+/**
+ * The edge names reachable in the outgoing (`->`) direction from a node:
+ * every registered edge whose `from` table is `Tb`. Resolved by scanning the
+ * edge schemas directly (rather than the one-hop adjacency map, which collapses
+ * `via` names across edges once a schema has more than one), so a `.out()` only
+ * accepts edges that actually originate at `Tb`. A node with no outgoing edges
+ * resolves to `never`, making `.out()` uncallable at compile time.
+ */
+export type OutgoingEdges<C extends WorkableContext, Tb extends string> = {
+	[K in keyof C["orm"]["tables"] &
+		string]: C["orm"]["tables"][K] extends EdgeSchema<
+		infer From,
+		// biome-ignore lint/suspicious/noExplicitAny: matching the edge's via/to/field generics
+		any,
+		// biome-ignore lint/suspicious/noExplicitAny: matching the edge's via/to/field generics
+		any,
+		// biome-ignore lint/suspicious/noExplicitAny: matching the edge's via/to/field generics
+		any
+	>
+		? Tb extends From
+			? K
+			: never
+		: never;
+}[keyof C["orm"]["tables"] & string];
+
+/**
+ * The edge names reachable in the incoming (`<-`) direction into a node: every
+ * registered edge whose `to` table is `Tb`.
+ */
+export type IncomingEdges<C extends WorkableContext, Tb extends string> = {
+	[K in keyof C["orm"]["tables"] &
+		string]: C["orm"]["tables"][K] extends EdgeSchema<
+		// biome-ignore lint/suspicious/noExplicitAny: matching the edge's from/via/field generics
+		any,
+		// biome-ignore lint/suspicious/noExplicitAny: matching the edge's from/via/field generics
+		any,
+		infer To,
+		// biome-ignore lint/suspicious/noExplicitAny: matching the edge's from/via/field generics
+		any
+	>
+		? Tb extends To
+			? K
+			: never
+		: never;
+}[keyof C["orm"]["tables"] & string];

--- a/src/types/classes.ts
+++ b/src/types/classes.ts
@@ -223,6 +223,37 @@ export class RecordType<
 	}
 }
 
+/**
+ * The result of a graph traversal (e.g. `->authored->post`). A traversal yields
+ * an array of record links to the table it lands on, so its inferred type is
+ * `RecordId<Tb>[]`. Carrying the target table name on `.tb` lets `.select()` and
+ * further `.out()`/`.in()` steps resolve against it, while the array `infer`
+ * keeps a bare traversal (dropped straight into a projection) correctly typed.
+ */
+export class GraphType<Tb extends string = string> extends AbstractType<
+	RecordId<Tb>[]
+> {
+	name = "graph" as const;
+	get expected() {
+		return `array<record<${String(this._tb)}>>`;
+	}
+
+	constructor(private _tb: Tb) {
+		super();
+	}
+
+	get tb() {
+		return this._tb;
+	}
+
+	validate(value: unknown): value is this["infer"] {
+		if (!Array.isArray(value)) return false;
+		return value.every(
+			(v) => v instanceof RecordId && String(v.table) === this._tb,
+		);
+	}
+}
+
 export type ObjectTypeInner = Record<string, AbstractType>;
 export class ObjectType<
 	T extends ObjectTypeInner = ObjectTypeInner,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,3 @@
 export * from "./display";
+export * from "./traversal";
 export * from "./workable";

--- a/src/utils/traversal.ts
+++ b/src/utils/traversal.ts
@@ -1,0 +1,38 @@
+import type { AbstractType } from "../types";
+import type { Actionable } from "./actionable";
+import type { WorkableContext } from "./workable";
+
+/** Traversal verbs that the row sugar exposes by delegating to the row's `id`. */
+const TRAVERSAL_VERBS = new Set(["out", "in", "outEdge", "inEdge"]);
+
+/**
+ * Wrap a row actionable so the traversal verbs (`out`, `in`, `outEdge`,
+ * `inEdge`) can be called directly on it — `user.out("authored")` instead of
+ * `user.id.out("authored")` — by delegating to the row's `id` record.
+ *
+ * A verb is only intercepted when the table has no field of that name, so a
+ * verb never shadows a real field. This matters for edge tables, whose `in` /
+ * `out` record-link fields must keep resolving as field access.
+ */
+export function traversableRow<
+	C extends WorkableContext,
+	T extends AbstractType,
+>(row: Actionable<C, T>, fields: Record<string, unknown>): Actionable<C, T> {
+	return new Proxy(row, {
+		get(target, prop) {
+			if (
+				typeof prop === "string" &&
+				TRAVERSAL_VERBS.has(prop) &&
+				!(prop in fields)
+			) {
+				// biome-ignore lint/suspicious/noExplicitAny: dynamic dispatch onto the row's id-record traversal verb
+				const idRecord = (target as any).id;
+				return (...args: unknown[]) =>
+					(idRecord as Record<string, (...a: unknown[]) => unknown>)[prop]!(
+						...args,
+					);
+			}
+			return target[prop as keyof typeof target];
+		},
+	}) as Actionable<C, T>;
+}

--- a/tests/integration/traversal.test.ts
+++ b/tests/integration/traversal.test.ts
@@ -179,6 +179,23 @@ describe("graph traversal integration tests", () => {
 
 		expect(result.map((r) => r.first)).toEqual(["Carol"]);
 	});
+
+	test("row-level sugar (user.out without .id)", async () => {
+		const { surreal } = getTestDb();
+		const db = orm(surreal, ...schema);
+
+		const result = await db
+			.select("user", "alice")
+			.return((u) => ({
+				posts: u
+					.out("authored")
+					.select()
+					.return((p) => ({ title: p.title })),
+			}))
+			.execute();
+
+		expect(result).toEqual([{ posts: [{ title: "First Post" }] }]);
+	});
 });
 
 describe("graph traversal — edge filtering", () => {
@@ -226,5 +243,71 @@ describe("graph traversal — edge filtering", () => {
 			.execute();
 
 		expect(result[0]!.posts.length).toBe(2);
+	});
+});
+
+describe("graph traversal — recursive / path finding", () => {
+	const person = table("person", { name: t.string() });
+	const knows = edge("person", "knows", "person", {});
+	const schema = [person, knows] as const;
+
+	const getTestDb = withTestDb({
+		setup: async ({ surreal }) => {
+			await surreal.query(`
+				CREATE person:alice, person:bob, person:carol, person:dave;
+				RELATE person:alice->knows->person:bob;
+				RELATE person:bob->knows->person:carol;
+				RELATE person:carol->knows->person:dave;
+			`);
+		},
+	});
+
+	const ids = (arr: { id: unknown }[] | RecordId[]) =>
+		(arr as RecordId[]).map((r) => String(r));
+
+	test("exact depth lands on the node at that depth", async () => {
+		const { surreal } = getTestDb();
+		const db = orm(surreal, ...schema);
+
+		const result = await db
+			.select("person", "alice")
+			.return((p) => ({ net: p.out("knows", { depth: 2 }) }))
+			.execute();
+
+		expect(ids(result[0]!.net)).toEqual(["person:carol"]);
+	});
+
+	test("collect gathers every node along the recursion", async () => {
+		const { surreal } = getTestDb();
+		const db = orm(surreal, ...schema);
+
+		const result = await db
+			.select("person", "alice")
+			.return((p) => ({ net: p.out("knows", { collect: true }) }))
+			.execute();
+
+		expect(ids(result[0]!.net).sort()).toEqual([
+			"person:bob",
+			"person:carol",
+			"person:dave",
+		]);
+	});
+
+	test("shortest finds the path to a target record", async () => {
+		const { surreal } = getTestDb();
+		const db = orm(surreal, ...schema);
+
+		const result = await db
+			.select("person", "alice")
+			.return((p) => ({
+				path: p.out("knows", { shortest: new RecordId("person", "dave") }),
+			}))
+			.execute();
+
+		expect(ids(result[0]!.path)).toEqual([
+			"person:bob",
+			"person:carol",
+			"person:dave",
+		]);
 	});
 });

--- a/tests/integration/traversal.test.ts
+++ b/tests/integration/traversal.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, test } from "bun:test";
+import { RecordId } from "surrealdb";
+import { edge, orm, t, table } from "../../src";
+import { withTestDb } from "./setup";
+
+describe("graph traversal integration tests", () => {
+	const user = table("user", {
+		name: t.object({ first: t.string(), last: t.string() }),
+		age: t.number(),
+	});
+	const post = table("post", { title: t.string() });
+	const tag = table("tag", { label: t.string() });
+	const authored = edge("user", "authored", "post", { created: t.date() });
+	const tagged = edge("post", "tagged", "tag", {});
+
+	const schema = [user, post, tag, authored, tagged] as const;
+
+	const getTestDb = withTestDb({
+		setup: async ({ surreal }) => {
+			await surreal.query(`
+				CREATE user:alice SET name = { first: "Alice", last: "Smith" }, age = 30;
+				CREATE user:bob   SET name = { first: "Bob", last: "Jones" }, age = 25;
+				CREATE user:carol SET name = { first: "Carol", last: "Lee" }, age = 40;
+				CREATE post:post1 SET title = "First Post";
+				CREATE post:post2 SET title = "Second Post";
+				CREATE tag:ts SET label = "typescript";
+				RELATE user:alice->authored->post:post1 SET created = time::now();
+				RELATE user:bob->authored->post:post2 SET created = time::now();
+				RELATE post:post1->tagged->tag:ts;
+			`);
+		},
+	});
+
+	test("outgoing single hop, projected via .select()", async () => {
+		const { surreal } = getTestDb();
+		const db = orm(surreal, ...schema);
+
+		const result = await db
+			.select("user", "alice")
+			.return((u) => ({
+				posts: u.id
+					.out("authored")
+					.select()
+					.return((p) => ({ title: p.title })),
+			}))
+			.execute();
+
+		expect(result).toEqual([{ posts: [{ title: "First Post" }] }]);
+	});
+
+	test("incoming single hop, projected via .select()", async () => {
+		const { surreal } = getTestDb();
+		const db = orm(surreal, ...schema);
+
+		const result = await db
+			.select("post", "post1")
+			.return((p) => ({
+				authors: p.id
+					.in("authored")
+					.select()
+					.return((u) => ({
+						first: u.name.first,
+					})),
+			}))
+			.execute();
+
+		expect(result).toEqual([{ authors: [{ first: "Alice" }] }]);
+	});
+
+	test("bare traversal yields record links", async () => {
+		const { surreal } = getTestDb();
+		const db = orm(surreal, ...schema);
+
+		const result = await db
+			.select("user", "alice")
+			.return((u) => ({ posts: u.id.out("authored") }))
+			.execute();
+
+		expect(result.length).toBe(1);
+		const posts = result[0]!.posts;
+		expect(posts.length).toBe(1);
+		expect(posts[0]).toBeInstanceOf(RecordId);
+		expect(String(posts[0])).toBe("post:post1");
+	});
+
+	test("multi-hop chaining ->authored->post->tagged->tag", async () => {
+		const { surreal } = getTestDb();
+		const db = orm(surreal, ...schema);
+
+		const result = await db
+			.select("user", "alice")
+			.return((u) => ({
+				tags: u.id
+					.out("authored")
+					.out("tagged")
+					.select()
+					.return((tg) => ({ label: tg.label })),
+			}))
+			.execute();
+
+		expect(result).toEqual([{ tags: [{ label: "typescript" }] }]);
+	});
+
+	test("empty traversal yields an empty array", async () => {
+		const { surreal } = getTestDb();
+		const db = orm(surreal, ...schema);
+
+		const result = await db
+			.select("user", "carol")
+			.return((u) => ({ posts: u.id.out("authored") }))
+			.execute();
+
+		expect(result).toEqual([{ posts: [] }]);
+	});
+
+	test("outEdge lands on the edge and exposes its fields", async () => {
+		const { surreal } = getTestDb();
+		const db = orm(surreal, ...schema);
+
+		const result = await db
+			.select("user", "alice")
+			.return((u) => ({
+				edges: u.id
+					.outEdge("authored")
+					.select()
+					.return((e) => ({
+						when: e.created,
+					})),
+			}))
+			.execute();
+
+		expect(result.length).toBe(1);
+		const edges = result[0]!.edges;
+		expect(edges.length).toBe(1);
+		expect(edges[0]!.when).toBeInstanceOf(Date);
+	});
+
+	test("inEdge lands on the incoming edge and exposes its fields", async () => {
+		const { surreal } = getTestDb();
+		const db = orm(surreal, ...schema);
+
+		const result = await db
+			.select("post", "post1")
+			.return((p) => ({
+				edges: p.id
+					.inEdge("authored")
+					.select()
+					.return((e) => ({
+						when: e.created,
+					})),
+			}))
+			.execute();
+
+		expect(result[0]!.edges[0]!.when).toBeInstanceOf(Date);
+	});
+
+	test("WHERE: array::len filters to nodes with a traversal", async () => {
+		const { surreal } = getTestDb();
+		const db = orm(surreal, ...schema);
+
+		const result = await db
+			.select("user")
+			.where((u) => u.id.out("authored").len().gt(0))
+			.return((u) => ({ first: u.name.first }))
+			.execute();
+
+		expect(result.map((r) => r.first).sort()).toEqual(["Alice", "Bob"]);
+	});
+
+	test("WHERE: array::is_empty filters to nodes without a traversal", async () => {
+		const { surreal } = getTestDb();
+		const db = orm(surreal, ...schema);
+
+		const result = await db
+			.select("user")
+			.where((u) => u.id.out("authored").isEmpty())
+			.return((u) => ({ first: u.name.first }))
+			.execute();
+
+		expect(result.map((r) => r.first)).toEqual(["Carol"]);
+	});
+});
+
+describe("graph traversal — edge filtering", () => {
+	const user = table("user", { name: t.string() });
+	const post = table("post", { title: t.string() });
+	const authored = edge("user", "authored", "post", { role: t.string() });
+	const schema = [user, post, authored] as const;
+
+	const getTestDb = withTestDb({
+		setup: async ({ surreal }) => {
+			await surreal.query(`
+				CREATE user:dave SET name = "Dave";
+				CREATE post:p1 SET title = "Authored";
+				CREATE post:p2 SET title = "Edited";
+				RELATE user:dave->authored->post:p1 SET role = "author";
+				RELATE user:dave->authored->post:p2 SET role = "editor";
+			`);
+		},
+	});
+
+	test("->(edge WHERE …)->target filters by edge field", async () => {
+		const { surreal } = getTestDb();
+		const db = orm(surreal, ...schema);
+
+		const result = await db
+			.select("user", "dave")
+			.return((u) => ({
+				authored: u.id
+					.out("authored", { where: (e) => e.role.eq("author") })
+					.select()
+					.return((p) => ({ title: p.title })),
+			}))
+			.execute();
+
+		expect(result).toEqual([{ authored: [{ title: "Authored" }] }]);
+	});
+
+	test("without a filter, all edges traverse", async () => {
+		const { surreal } = getTestDb();
+		const db = orm(surreal, ...schema);
+
+		const result = await db
+			.select("user", "dave")
+			.return((u) => ({ posts: u.id.out("authored") }))
+			.execute();
+
+		expect(result[0]!.posts.length).toBe(2);
+	});
+});

--- a/tests/unit/query/traversal.test.ts
+++ b/tests/unit/query/traversal.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from "bun:test";
+import type { RecordId } from "surrealdb";
+import { Surreal } from "surrealdb";
+import {
+	__display,
+	displayContext,
+	edge,
+	type IncomingEdges,
+	type OutgoingEdges,
+	orm,
+	type ToOf,
+	t,
+	table,
+} from "../../../src";
+
+// Compile-time equality assertion helper.
+type Equal<A, B> =
+	(<G>() => G extends A ? 1 : 2) extends <G>() => G extends B ? 1 : 2
+		? true
+		: false;
+
+const user = table("user", {
+	name: t.object({ first: t.string(), last: t.string() }),
+	age: t.number(),
+});
+const post = table("post", { title: t.string() });
+const tag = table("tag", { label: t.string() });
+const authored = edge("user", "authored", "post", {
+	created: t.date(),
+	role: t.string(),
+});
+const tagged = edge("post", "tagged", "tag", {});
+
+const db = orm(new Surreal(), user, post, tag, authored, tagged);
+
+const render = (q: {
+	[__display]: (ctx: ReturnType<typeof displayContext>) => string;
+}) => q[__display](displayContext());
+
+describe("graph traversal — SurrealQL generation", () => {
+	test("outgoing single hop: ->edge->target", () => {
+		const q = db
+			.select("user")
+			.return((u) => ({ posts: u.id.out("authored") }));
+		const sql = render(q);
+		expect(sql).toContain("->authored->post");
+		expect(sql).toContain("$this.id->authored->post");
+	});
+
+	test("incoming single hop: <-edge<-source", () => {
+		const q = db
+			.select("post")
+			.return((p) => ({ authors: p.id.in("authored") }));
+		const sql = render(q);
+		expect(sql).toContain("<-authored<-user");
+	});
+
+	test("multi-hop chaining: ->authored->post->tagged->tag", () => {
+		const q = db
+			.select("user")
+			.return((u) => ({ tags: u.id.out("authored").out("tagged") }));
+		const sql = render(q);
+		expect(sql).toContain("->authored->post->tagged->tag");
+	});
+
+	test("outEdge lands on the edge, not the far node", () => {
+		const q = db
+			.select("user")
+			.return((u) => ({ edges: u.id.outEdge("authored") }));
+		const sql = render(q);
+		expect(sql).toContain("->authored");
+		expect(sql).not.toContain("->authored->post");
+	});
+
+	test("inEdge lands on the edge in the incoming direction", () => {
+		const q = db
+			.select("post")
+			.return((p) => ({ edges: p.id.inEdge("authored") }));
+		const sql = render(q);
+		expect(sql).toContain("<-authored");
+		expect(sql).not.toContain("<-authored<-user");
+	});
+
+	test("WHERE: array::len over a traversal", () => {
+		const q = db.select("user").where((u) => u.id.out("authored").len().gt(0));
+		const sql = render(q);
+		expect(sql).toContain("array::len($this.id->authored->post)");
+		expect(sql).toContain(" > ");
+	});
+
+	test("WHERE: array::is_empty over a traversal", () => {
+		const q = db.select("user").where((u) => u.id.out("authored").isEmpty());
+		const sql = render(q);
+		expect(sql).toContain("array::is_empty($this.id->authored->post)");
+	});
+
+	test("edge filtering: ->(edge WHERE …)->target", () => {
+		const q = db.select("user").return((u) => ({
+			posts: u.id.out("authored", { where: (e) => e.role.eq("author") }),
+		}));
+		const sql = render(q);
+		expect(sql).toContain("->(authored WHERE role = ");
+		expect(sql).toContain(")->post");
+	});
+
+	test(".select().return() wraps the traversal in a subquery", () => {
+		const q = db.select("user").return((u) => ({
+			posts: u.id
+				.out("authored")
+				.select()
+				.return((p) => ({ title: p.title })),
+		}));
+		const sql = render(q);
+		expect(sql).toContain("SELECT VALUE");
+		expect(sql).toContain("->authored->post");
+		// inside the nested subquery the outer row is referenced as $parent
+		expect(sql).toContain("$parent.id->authored->post");
+	});
+
+	test("bare step renders inside a projection", () => {
+		const q = db
+			.select("user")
+			.return((u) => ({ posts: u.id.out("authored") }));
+		const sql = render(q);
+		expect(sql).toContain("{ posts: $this.id->authored->post }");
+	});
+});
+
+describe("graph traversal — type-level", () => {
+	type Ctx = { orm: typeof db; id: symbol };
+
+	test("edge → table resolution", () => {
+		const _to: Equal<ToOf<Ctx, "authored">, "post"> = true;
+		const _tagged: Equal<ToOf<Ctx, "tagged">, "tag"> = true;
+		expect(_to && _tagged).toBe(true);
+	});
+
+	test("edge enumeration per direction", () => {
+		const _out: Equal<OutgoingEdges<Ctx, "user">, "authored"> = true;
+		const _in: Equal<IncomingEdges<Ctx, "post">, "authored"> = true;
+		expect(_out && _in).toBe(true);
+	});
+
+	test("bare traversal infers as an array of record links", () => {
+		const q = db
+			.select("user")
+			.return((u) => ({ posts: u.id.out("authored") }));
+		type R = t.infer<typeof q>;
+		const _check: Equal<R, { posts: RecordId<"post">[] }[]> = true;
+		expect(_check).toBe(true);
+	});
+
+	test("projected .select() infers as an array of the projection", () => {
+		const q = db.select("user").return((u) => ({
+			posts: u.id
+				.out("authored")
+				.select()
+				.return((p) => ({ title: p.title })),
+		}));
+		type R = t.infer<typeof q>;
+		const _check: Equal<R, { posts: { title: string }[] }[]> = true;
+		expect(_check).toBe(true);
+	});
+
+	test("traversing a non-existent / wrong-direction edge is a type error", () => {
+		// Never invoked — present only so `tsc` checks the @ts-expect-error cases.
+		const _typeErrors = () => {
+			db.select("user").return((u) => ({
+				// @ts-expect-error "nope" is not an outgoing edge of user
+				x: u.id.out("nope"),
+			}));
+			db.select("user").return((u) => ({
+				// @ts-expect-error "tagged" starts at post, not user
+				x: u.id.out("tagged"),
+			}));
+		};
+		expect(typeof _typeErrors).toBe("function");
+	});
+});

--- a/tests/unit/query/traversal.test.ts
+++ b/tests/unit/query/traversal.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { RecordId } from "surrealdb";
-import { Surreal } from "surrealdb";
+import { RecordId, Surreal } from "surrealdb";
 import {
 	__display,
 	displayContext,
@@ -175,5 +174,91 @@ describe("graph traversal — type-level", () => {
 			}));
 		};
 		expect(typeof _typeErrors).toBe("function");
+	});
+});
+
+describe("graph traversal — row-level sugar", () => {
+	test("user.out(edge) roots at the row's id", () => {
+		const q = db.select("user").return((u) => ({ posts: u.out("authored") }));
+		const sql = render(q);
+		expect(sql).toContain("$this.id->authored->post");
+	});
+
+	test("sugar works in WHERE", () => {
+		const q = db.select("user").where((u) => u.out("authored").len().gt(0));
+		const sql = render(q);
+		expect(sql).toContain("array::len($this.id->authored->post)");
+	});
+
+	test("sugar matches the explicit .id form", () => {
+		const sugar = render(
+			db.select("user").return((u) => ({ posts: u.out("authored") })),
+		);
+		const explicit = render(
+			db.select("user").return((u) => ({ posts: u.id.out("authored") })),
+		);
+		expect(sugar).toBe(explicit);
+	});
+
+	test("does not shadow an edge table's in/out fields", () => {
+		// Selecting the `authored` edge: `in`/`out` must stay field accesses.
+		const q = db.select("authored").return((e) => ({ from: e.in, to: e.out }));
+		const sql = render(q);
+		expect(sql).toContain("$this.in");
+		expect(sql).toContain("$this.out");
+		expect(sql).not.toContain("->");
+		expect(sql).not.toContain("<-");
+	});
+});
+
+describe("graph traversal — recursive / path finding", () => {
+	const person = table("person", { name: t.string() });
+	const knows = edge("person", "knows", "person", {});
+	const rdb = orm(new Surreal(), person, knows);
+
+	test("range depth: head.{min..max}(->edge->target)", () => {
+		const q = rdb
+			.select("person")
+			.return((p) => ({ net: p.out("knows", { depth: [1, 3] }) }));
+		expect(render(q)).toContain("$this.id.{1..3}(->knows->person)");
+	});
+
+	test("exact depth: .{n}", () => {
+		const q = rdb
+			.select("person")
+			.return((p) => ({ net: p.out("knows", { depth: 2 }) }));
+		expect(render(q)).toContain(".{2}(->knows->person)");
+	});
+
+	test("open-ended depth: .{..max}", () => {
+		const q = rdb
+			.select("person")
+			.return((p) => ({ net: p.out("knows", { depth: { max: 5 } }) }));
+		expect(render(q)).toContain(".{..5}(->knows->person)");
+	});
+
+	test("collect modifier: .{..+collect}", () => {
+		const q = rdb
+			.select("person")
+			.return((p) => ({ net: p.out("knows", { collect: true }) }));
+		expect(render(q)).toContain(".{..+collect}(->knows->person)");
+	});
+
+	test("shortest path binds the target as a parameter", () => {
+		const target = new RecordId("person", "z");
+		const q = rdb
+			.select("person")
+			.return((p) => ({ path: p.out("knows", { shortest: target }) }));
+		const ctx = displayContext();
+		const sql = q[__display](ctx);
+		expect(sql).toMatch(/\.\{\.\.\+shortest=\$_v\d+\}\(->knows->person\)/);
+		expect(Object.values(ctx.variables)).toContainEqual(target);
+	});
+
+	test("recursion composes with an edge filter", () => {
+		const q = rdb.select("person").return((p) => ({
+			net: p.out("knows", { depth: [1, 2], where: (e) => e.id.trueish() }),
+		}));
+		expect(render(q)).toContain(".{1..2}(->(knows WHERE");
 	});
 });


### PR DESCRIPTION
## Summary

Implements full **type-safe graph traversal** — the headline feature that was previously only scaffolded (`lookup` metadata + no-op `.to()`/`.from()` stubs, marked *"under active development"*). For a graph-first SurrealDB ORM this is the key differentiator versus Drizzle/Prisma, and a gating feature for 1.0.

A traversal is just a `Workable` carrying a new `GraphType<Tb>` whose `__display` appends `->edge->target` / `<-edge<-source`, so it plugs into the existing nested-`.select()` machinery — no new query-rendering pipeline.

## What's included

- **Outgoing / incoming navigation** — `.out(edge)` / `.in(edge)`, type-checked against the schema's edges (wrong-direction or unknown edges are compile errors).
- **Multi-hop chaining** — re-typed against each landing table (`user.out("authored").out("tagged")`).
- **Bare steps** infer as record-link arrays (`RecordId<Tb>[]`); `.select().return(...)` materialises full records / projections.
- **Edge-field access** — `.outEdge()` / `.inEdge()` land on the edge to read its own fields (`created`, `role`).
- **WHERE predicates** — `len()` / `isEmpty()` / `contains()` over a traversal (`array::len(->authored->post) > 0`).
- **Edge filtering** — `.out("authored", { where: e => e.role.eq("author") })` → `->(authored WHERE …)->target`.
- **Row-level sugar** — `user.out("authored")` directly on a select row (rooted at the row's `id`), without shadowing edge tables' `in`/`out` fields.
- **Recursive / path-finding** — `depth` (exact/range/open), `collect` (`{..+collect}`), and `shortest` (`{..+shortest=$target}`), compiling to SurrealDB's `record.{depth}(->edge->target)` idiom.

## Why this approach

- **Edge enumeration scans the `EdgeSchema` generics directly** rather than the one-hop `lookup` adjacency type. The lookup type collapses `via` names into a union once a schema has 2+ edges (fine for one edge, imprecise otherwise), which would let `user.out("someOtherEdge")` type-check. `db.lookup` itself is unchanged.
- **`GraphType<Tb>`** carries the landing table on `.tb` (so `.select()` and chaining resolve) while inferring as an array (so bare steps and `t.infer` report `RecordId<Tb>[]`).
- **`shortest` binds its target as a parameter** (verified SurrealDB accepts `+shortest=$param`) rather than inlining a record id.

## Verification

Verified against a live **SurrealDB 3.1.2** (incl. confirming the recursive `.{}(path)` parenthesised syntax — the block form does not parse).

- **683 pass, 0 fail** — 40 new traversal tests (25 unit: SurrealQL strings + type-level `Equal<>` + `@ts-expect-error`; 15 integration).
- `tsc --noEmit` clean; build incl. `.d.ts` succeeds; Biome clean on changed files.

## Reviewer notes

- **New public surface** (frozen at 1.0): `GraphType`, and the traversal types in `src/schema/traversal.ts` (`ToOf`, `FromOf`, `OutgoingEdges`, `IncomingEdges`, `RowTraversal`, `TraverseOpts`, `RecurseOpts`, `RecurseDepth`).
- **Scoped out:** graph algorithms beyond shortest-path (e.g. weighted / `+path` collection variants) — easy to add on top of the `Recursion` plumbing.
- README "Graph traversal" section replaces the old placeholder; both roadmap graph boxes are ticked.