### PR TITLE
Curate public API surface ahead of 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ npm install surqlize
   features degrade or are unavailable on older servers; for example, filtering
   or projecting a live query relies on query parameters that require **server ≥
   3.0** (`FETCH` requires ≥ 2.2.0).
-- **`surrealdb` JavaScript SDK ≥ 2.0.0-alpha.18** — declared as a peer
+- **`surrealdb` JavaScript SDK ≥ 2.0.0** — declared as a peer
   dependency, so install it alongside surqlize. (The SDK and the server are
   versioned independently: the 2.x SDK is what connects to a 3.x server.)
 - **TypeScript ≥ 5.0** for full type inference.
@@ -1562,7 +1562,7 @@ bun run qau  # Auto-fix with unsafe changes
 
 ## Contributing
 
-Contributions are welcome! This project is in an experimental stage, so expect breaking changes. If you'd like to contribute:
+Contributions are welcome! The project is stabilizing toward a `1.0.0` release; the public API is largely settled, but minor breaking changes are still possible before then. If you'd like to contribute:
 
 1. Open an issue to discuss your idea
 2. Fork the repository

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"tsup": "^8.5.1"
 	},
 	"peerDependencies": {
-		"surrealdb": ">=2.0.0-alpha.18",
+		"surrealdb": ">=2.0.0",
 		"typescript": "^5.0.0"
 	},
 	"scripts": {

--- a/src/functions/standalone/bytes.ts
+++ b/src/functions/standalone/bytes.ts
@@ -1,6 +1,6 @@
 import { t } from "../../types";
 import type { Workable, WorkableContext } from "../../utils";
-import { standaloneFn } from "./index";
+import { standaloneFn } from "./internal";
 
 export const bytes = {
 	len<C extends WorkableContext>(value: Workable<C>) {

--- a/src/functions/standalone/count.ts
+++ b/src/functions/standalone/count.ts
@@ -1,6 +1,6 @@
 import { t } from "../../types";
 import type { Workable, WorkableContext } from "../../utils";
-import { type ContextSource, standaloneFn } from "./index";
+import { type ContextSource, standaloneFn } from "./internal";
 
 /** count() - counts a row, or counts truthy values if a value is given */
 export function count<C extends WorkableContext>(

--- a/src/functions/standalone/crypto.ts
+++ b/src/functions/standalone/crypto.ts
@@ -1,6 +1,6 @@
 import { t } from "../../types";
 import type { Workable, WorkableContext } from "../../utils";
-import { standaloneFn } from "./index";
+import { standaloneFn } from "./internal";
 
 export const crypto = {
 	// Hashing functions

--- a/src/functions/standalone/duration.ts
+++ b/src/functions/standalone/duration.ts
@@ -1,6 +1,6 @@
 import { t } from "../../types";
 import type { Workable, WorkableContext } from "../../utils";
-import { type ContextSource, standaloneConst, standaloneFn } from "./index";
+import { type ContextSource, standaloneConst, standaloneFn } from "./internal";
 
 export const duration = {
 	// Extraction functions

--- a/src/functions/standalone/encoding.ts
+++ b/src/functions/standalone/encoding.ts
@@ -1,6 +1,6 @@
 import { t } from "../../types";
 import type { Workable, WorkableContext } from "../../utils";
-import { standaloneFn } from "./index";
+import { standaloneFn } from "./internal";
 
 export const encoding = {
 	base64Decode<C extends WorkableContext>(value: Workable<C>) {

--- a/src/functions/standalone/geo.ts
+++ b/src/functions/standalone/geo.ts
@@ -1,6 +1,6 @@
 import { t } from "../../types";
 import type { Workable, WorkableContext } from "../../utils";
-import { standaloneFn } from "./index";
+import { standaloneFn } from "./internal";
 
 export const geo = {
 	area<C extends WorkableContext>(value: Workable<C>) {

--- a/src/functions/standalone/http.ts
+++ b/src/functions/standalone/http.ts
@@ -1,6 +1,6 @@
 import { t } from "../../types";
 import type { Workable, WorkableContext } from "../../utils";
-import { standaloneFn } from "./index";
+import { standaloneFn } from "./internal";
 
 export const http = {
 	head<C extends WorkableContext>(url: Workable<C>) {

--- a/src/functions/standalone/index.ts
+++ b/src/functions/standalone/index.ts
@@ -1,72 +1,9 @@
-import type { AbstractType } from "../../types";
-import {
-	__ctx,
-	__display,
-	__type,
-	isWorkable,
-	type Workable,
-	type WorkableContext,
-} from "../../utils";
-import { type Actionable, actionable } from "../../utils/actionable";
-
-/**
- * Context source for standalone functions.
- * Accepts either a WorkableContext directly or a Workable to extract context from.
- */
-export type ContextSource<C extends WorkableContext = WorkableContext> =
-	| C
-	| Workable<C>;
-
-/**
- * Extract a WorkableContext from either a raw context or a Workable.
- */
-export function extractContext<C extends WorkableContext>(
-	source: ContextSource<C>,
-): C {
-	if (isWorkable(source)) {
-		return source[__ctx];
-	}
-	return source as C;
-}
-
-/**
- * Create a standalone database function that generates SurrealQL like `fn_name(param1, param2)`.
- * Unlike databaseFunction in ../utils.ts, this doesn't require a pre-existing Workable context binding.
- */
-export function standaloneFn<C extends WorkableContext, T extends AbstractType>(
-	source: ContextSource<C>,
-	type: T,
-	fn: string,
-	...params: Workable<C>[]
-): Actionable<C, T> {
-	const ctx = extractContext(source);
-	return actionable({
-		[__ctx]: ctx,
-		[__type]: type,
-		[__display](ctx) {
-			const vars = params.map((p) => p[__display](ctx)).join(", ");
-			return vars ? `${fn}(${vars})` : `${fn}()`;
-		},
-	});
-}
-
-/**
- * Create a standalone constant reference (no parentheses).
- * Generates SurrealQL like `math::pi` or `math::e`.
- */
-export function standaloneConst<
-	C extends WorkableContext,
-	T extends AbstractType,
->(source: ContextSource<C>, type: T, name: string): Actionable<C, T> {
-	const ctx = extractContext(source);
-	return actionable({
-		[__ctx]: ctx,
-		[__type]: type,
-		[__display]() {
-			return name;
-		},
-	});
-}
+// Standalone function families.
+//
+// The internal builders (`standaloneFn`, `standaloneConst`, `extractContext`)
+// live in ./internal and are intentionally NOT re-exported — they are
+// implementation plumbing. `ContextSource` is re-exported because it appears in
+// the public signatures of the families below.
 
 export * from "./and";
 export * from "./bytes";
@@ -76,6 +13,7 @@ export * from "./duration";
 export * from "./encoding";
 export * from "./geo";
 export * from "./http";
+export type { ContextSource } from "./internal";
 export * from "./math";
 export * from "./meta";
 export * from "./not";

--- a/src/functions/standalone/internal.ts
+++ b/src/functions/standalone/internal.ts
@@ -1,0 +1,78 @@
+import type { AbstractType } from "../../types";
+import {
+	__ctx,
+	__display,
+	__type,
+	isWorkable,
+	type Workable,
+	type WorkableContext,
+} from "../../utils";
+import { type Actionable, actionable } from "../../utils/actionable";
+
+/**
+ * Context source for standalone functions.
+ * Accepts either a WorkableContext directly or a Workable to extract context from.
+ *
+ * This type is part of the public surface because it appears in the signatures
+ * of the standalone function families.
+ */
+export type ContextSource<C extends WorkableContext = WorkableContext> =
+	| C
+	| Workable<C>;
+
+/**
+ * Extract a WorkableContext from either a raw context or a Workable.
+ *
+ * @internal Implementation detail of the standalone function builders.
+ */
+export function extractContext<C extends WorkableContext>(
+	source: ContextSource<C>,
+): C {
+	if (isWorkable(source)) {
+		return source[__ctx];
+	}
+	return source as C;
+}
+
+/**
+ * Create a standalone database function that generates SurrealQL like `fn_name(param1, param2)`.
+ * Unlike databaseFunction in ../utils.ts, this doesn't require a pre-existing Workable context binding.
+ *
+ * @internal Used to build the standalone function families.
+ */
+export function standaloneFn<C extends WorkableContext, T extends AbstractType>(
+	source: ContextSource<C>,
+	type: T,
+	fn: string,
+	...params: Workable<C>[]
+): Actionable<C, T> {
+	const ctx = extractContext(source);
+	return actionable({
+		[__ctx]: ctx,
+		[__type]: type,
+		[__display](ctx) {
+			const vars = params.map((p) => p[__display](ctx)).join(", ");
+			return vars ? `${fn}(${vars})` : `${fn}()`;
+		},
+	});
+}
+
+/**
+ * Create a standalone constant reference (no parentheses).
+ * Generates SurrealQL like `math::pi` or `math::e`.
+ *
+ * @internal Used to build the standalone function families.
+ */
+export function standaloneConst<
+	C extends WorkableContext,
+	T extends AbstractType,
+>(source: ContextSource<C>, type: T, name: string): Actionable<C, T> {
+	const ctx = extractContext(source);
+	return actionable({
+		[__ctx]: ctx,
+		[__type]: type,
+		[__display]() {
+			return name;
+		},
+	});
+}

--- a/src/functions/standalone/math.ts
+++ b/src/functions/standalone/math.ts
@@ -1,6 +1,6 @@
 import { t } from "../../types";
 import type { Workable, WorkableContext } from "../../utils";
-import { type ContextSource, standaloneConst, standaloneFn } from "./index";
+import { type ContextSource, standaloneConst, standaloneFn } from "./internal";
 
 export const math = {
 	// Aggregation functions (single array param)

--- a/src/functions/standalone/meta.ts
+++ b/src/functions/standalone/meta.ts
@@ -1,6 +1,6 @@
 import { t } from "../../types";
 import type { Workable, WorkableContext } from "../../utils";
-import { standaloneFn } from "./index";
+import { standaloneFn } from "./internal";
 
 export const meta = {
 	id<C extends WorkableContext>(value: Workable<C>) {

--- a/src/functions/standalone/not.ts
+++ b/src/functions/standalone/not.ts
@@ -1,6 +1,6 @@
 import { t } from "../../types";
 import type { Workable, WorkableContext } from "../../utils";
-import { standaloneFn } from "./index";
+import { standaloneFn } from "./internal";
 
 /** not(value) - logical negation */
 export function not<C extends WorkableContext>(value: Workable<C>) {

--- a/src/functions/standalone/object.ts
+++ b/src/functions/standalone/object.ts
@@ -1,6 +1,6 @@
 import { t } from "../../types";
 import type { Workable, WorkableContext } from "../../utils";
-import { standaloneFn } from "./index";
+import { standaloneFn } from "./internal";
 
 export const object = {
 	entries<C extends WorkableContext>(value: Workable<C>) {

--- a/src/functions/standalone/parse.ts
+++ b/src/functions/standalone/parse.ts
@@ -1,6 +1,6 @@
 import { t } from "../../types";
 import type { Workable, WorkableContext } from "../../utils";
-import { standaloneFn } from "./index";
+import { standaloneFn } from "./internal";
 
 export const parse = {
 	emailHost<C extends WorkableContext>(value: Workable<C>) {

--- a/src/functions/standalone/rand.ts
+++ b/src/functions/standalone/rand.ts
@@ -1,6 +1,6 @@
 import { t } from "../../types";
 import type { Workable, WorkableContext } from "../../utils";
-import { type ContextSource, standaloneFn } from "./index";
+import { type ContextSource, standaloneFn } from "./internal";
 
 export const rand = {
 	rand<C extends WorkableContext>(source: ContextSource<C>) {

--- a/src/functions/standalone/search.ts
+++ b/src/functions/standalone/search.ts
@@ -1,6 +1,6 @@
 import { t } from "../../types";
 import type { Workable, WorkableContext } from "../../utils";
-import { standaloneFn } from "./index";
+import { standaloneFn } from "./internal";
 
 export const search = {
 	analyze<C extends WorkableContext>(

--- a/src/functions/standalone/session.ts
+++ b/src/functions/standalone/session.ts
@@ -1,6 +1,6 @@
 import { t } from "../../types";
 import type { WorkableContext } from "../../utils";
-import { type ContextSource, standaloneFn } from "./index";
+import { type ContextSource, standaloneFn } from "./internal";
 
 export const session = {
 	ac<C extends WorkableContext>(source: ContextSource<C>) {

--- a/src/functions/standalone/set.ts
+++ b/src/functions/standalone/set.ts
@@ -1,7 +1,10 @@
 import { t } from "../../types";
 import type { Workable, WorkableContext } from "../../utils";
-import { standaloneFn } from "./index";
+import { standaloneFn } from "./internal";
 
+// Named `set_` (trailing underscore) for consistency with `type_` (which must
+// avoid the `export { type }` syntax collision). Maps to the SurrealQL `set`
+// function family.
 export const set_ = {
 	difference<C extends WorkableContext>(a: Workable<C>, b: Workable<C>) {
 		return standaloneFn(a, t.string(), "set::difference", a, b);

--- a/src/functions/standalone/sleep.ts
+++ b/src/functions/standalone/sleep.ts
@@ -1,6 +1,6 @@
 import { t } from "../../types";
 import type { Workable, WorkableContext } from "../../utils";
-import { standaloneFn } from "./index";
+import { standaloneFn } from "./internal";
 
 /** sleep(duration) - pauses execution */
 export function sleep<C extends WorkableContext>(duration: Workable<C>) {

--- a/src/functions/standalone/time.ts
+++ b/src/functions/standalone/time.ts
@@ -1,6 +1,6 @@
 import { t } from "../../types";
 import type { Workable, WorkableContext } from "../../utils";
-import { type ContextSource, standaloneConst, standaloneFn } from "./index";
+import { type ContextSource, standaloneConst, standaloneFn } from "./internal";
 
 export const time = {
 	// Functions

--- a/src/functions/standalone/type.ts
+++ b/src/functions/standalone/type.ts
@@ -1,7 +1,11 @@
 import { t } from "../../types";
 import type { Workable, WorkableContext } from "../../utils";
-import { standaloneFn } from "./index";
+import { standaloneFn } from "./internal";
 
+// Named `type_` (trailing underscore) rather than `type`: a binding literally
+// named `type` cannot be re-exported, because `export { type }` collides with
+// TypeScript's type-only export syntax (`export type { ... }`). The SurrealQL
+// family this maps to is `type::*`.
 export const type_ = {
 	// Casting functions
 

--- a/src/functions/standalone/value.ts
+++ b/src/functions/standalone/value.ts
@@ -1,6 +1,6 @@
 import { t } from "../../types";
 import type { Workable, WorkableContext } from "../../utils";
-import { standaloneFn } from "./index";
+import { standaloneFn } from "./internal";
 
 export const value = {
 	diff<C extends WorkableContext>(a: Workable<C>, b: Workable<C>) {

--- a/src/functions/standalone/vector.ts
+++ b/src/functions/standalone/vector.ts
@@ -1,6 +1,6 @@
 import { t } from "../../types";
 import type { Workable, WorkableContext } from "../../utils";
-import { standaloneFn } from "./index";
+import { standaloneFn } from "./internal";
 
 export const vector = {
 	add<C extends WorkableContext>(a: Workable<C>, b: Workable<C>) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,13 @@
+// Public API surface.
+//
+// Modules whose every export is intended for consumers are re-exported with a
+// wildcard. The `./utils` barrel is the one exception: it also contains internal
+// plumbing, so it is re-exported explicitly to keep that plumbing private.
+
 export * from "./error";
+// Standalone function families (internal builders kept private in ./internal)
 export * from "./functions/standalone";
+// Query builders
 export * from "./query/api";
 export * from "./query/batch";
 export * from "./query/create";
@@ -11,6 +19,21 @@ export * from "./query/select";
 export * from "./query/transaction";
 export * from "./query/update";
 export * from "./query/upsert";
+// Schema builders (orm, table, edge, fn, api) and their types
 export * from "./schema";
+// Type system: the `t.*` builders and the `*Type` classes
 export * from "./types";
-export * from "./utils";
+export type {
+	DisplayContext,
+	IntoWorkable,
+	Workable,
+	WorkableContext,
+} from "./utils";
+// Low-level utilities.
+//
+// The `./utils` barrel additionally exports internal plumbing — `intoWorkable`,
+// `isWorkable`, `sanitizeWorkable`, `workableGet`, `createVariableStore` — which
+// is deliberately NOT re-exported here. Only the documented escape hatch
+// (`displayContext` / `__display`) and the structural types that appear in
+// public signatures are part of the surface.
+export { __ctx, __display, __type, displayContext } from "./utils";

--- a/src/schema/function.ts
+++ b/src/schema/function.ts
@@ -1,5 +1,7 @@
-import type { ContextSource } from "../functions/standalone";
-import { standaloneFn } from "../functions/standalone";
+import {
+	type ContextSource,
+	standaloneFn,
+} from "../functions/standalone/internal";
 import type { AbstractType } from "../types";
 import type { Workable, WorkableContext } from "../utils";
 import type { Actionable } from "../utils/actionable";


### PR DESCRIPTION
## Why

Groundwork toward a stable `1.0.0` release. Two things blocked a credible SemVer promise: the `surrealdb` peer dependency was pinned to an **alpha** pre-release, and the package entry point used 16 wildcard `export *` lines that leaked internal plumbing into the public API.

## Changes

**Dependency & docs**
- Require `surrealdb >=2.0.0` (drop the `2.0.0-alpha.18` pre-release pin); update README requirements to match.
- Replace the "experimental, expect breaking changes" framing with "stabilizing toward 1.0.0, API largely settled".

**Public surface curation**
- `index.ts` now uses a hybrid approach: `export *` for fully-public modules, and an **explicit** re-export for `./utils` (the one module that mixes public API with internal plumbing).
- Hidden from the package entry point (9 symbols): `intoWorkable`, `isWorkable`, `sanitizeWorkable`, `workableGet`, `createVariableStore`, `traversableRow`, and the standalone function builders `standaloneFn` / `standaloneConst` / `extractContext` (moved into a new `functions/standalone/internal.ts`).
- Kept public deliberately: `__ctx`/`__type`/`__display` (computed keys in exported classes — must be exported), `Workable`/`WorkableContext`/`IntoWorkable`/`ContextSource`/`DisplayContext` (appear in public signatures; hiding them would cause "cannot be named" errors downstream), and `displayContext` (documented debugging escape hatch).

**Naming**
- Documented why the `set_` / `type_` families carry trailing underscores (`export { type }` collides with TypeScript's type-only export syntax; `set_` follows for consistency).

## Impact

Public surface: **100 symbols (was 109)**. Verified with a back-to-back build diff that the change removes exactly the 9 intended internal symbols and surfaces nothing new.

## Verification

- `tsc --noEmit` clean
- 562/562 unit tests pass
- `biome check` clean
- `tsup` build clean

Integration tests not run (require a local SurrealDB on `ws://localhost:8000`).