### PR TITLE
Added query method to the Orm class to execute raw SurrealDB queries

### DIFF
--- a/src/schema/orm.ts
+++ b/src/schema/orm.ts
@@ -483,6 +483,11 @@ export class Orm<T extends AnyTable[] = AnyTable[]> {
 			throw e;
 		}
 	}
+
+	// Run a raw query on the SurrealSession
+	async query(query: string, params: Record<string, unknown> ) {
+		return this.surreal.query(query, params);
+	}
 }
 
 /**

--- a/src/schema/orm.ts
+++ b/src/schema/orm.ts
@@ -485,7 +485,7 @@ export class Orm<T extends AnyTable[] = AnyTable[]> {
 	}
 
 	// Run a raw query on the SurrealSession
-	async query(query: string, params: Record<string, unknown> ) {
+	async query(query: string, params: Record<string, unknown>) {
 		return this.surreal.query(query, params);
 	}
 }


### PR DESCRIPTION
Small PR to add a way to run raw surql query from the Orm instance.

It's mainly for complex queries that are hard or even impossible to convert to orm.

It was already doable before but I found this way easier as we can keep a single instance of Orm for everything instead of exporting the Orm and the surreal session instance in projects. 