### PR TITLE
Support polymorphic / multi-table SELECT

### DIFF
--- a/src/query/delete.ts
+++ b/src/query/delete.ts
@@ -23,6 +23,7 @@ import {
 	type WorkableContext,
 } from "../utils/workable.ts";
 import { Query } from "./abstract.ts";
+import { resolveSubjectSchema } from "./subject.ts";
 
 /**
  * A fluent DELETE query builder. Supports WHERE, RETURN, and TIMEOUT clauses.
@@ -37,7 +38,7 @@ export class DeleteQuery<
 	private _filter?: Workable<C>;
 	private _return?: "none" | "before" | "after" | "diff" | Workable<C, E>;
 	private _timeout?: string;
-	private tb: T;
+	private tb: T | readonly T[];
 	private subject: T | RecordId<T> | Workable<C, RecordType<T>>;
 
 	constructor(orm: O, subject: T | RecordId<T> | Workable<C, RecordType<T>>) {
@@ -52,14 +53,15 @@ export class DeleteQuery<
 		if (typeof subject === "string") {
 			this.tb = subject;
 		} else if (isWorkable(subject)) {
-			this.tb = subject[__type].tb as T;
+			// A polymorphic link (`t.record(["a", "b"])`) carries an array here.
+			this.tb = (subject[__type] as RecordType<T>).tb;
 		} else {
-			this.tb = String(subject.table) as T;
+			this.tb = String((subject as RecordId<T>).table) as T;
 		}
 	}
 
 	get schema(): E {
-		return this[__ctx].orm.tables[this.tb]!.schema as unknown as E;
+		return resolveSubjectSchema(this[__ctx].orm, this.tb) as unknown as E;
 	}
 
 	get [__type](): ArrayType<E> {
@@ -72,7 +74,7 @@ export class DeleteQuery<
 	where(cb: (tb: Actionable<C, O["tables"][T]["schema"]>) => Workable<C>) {
 		const tb = actionable({
 			[__ctx]: this[__ctx],
-			[__type]: this[__ctx].orm.tables[this.tb]!.schema,
+			[__type]: resolveSubjectSchema(this[__ctx].orm, this.tb),
 			[__display]: ({ contextId }) => {
 				return contextId === this[__ctx].id ? "$this" : "$parent";
 			},
@@ -136,7 +138,7 @@ export class DeleteQuery<
 
 		const thing =
 			typeof this.subject === "string"
-				? ctx.var(new Table(this.tb))
+				? ctx.var(new Table(this.subject))
 				: isWorkable(this.subject)
 					? this.subject[__display](ctx)
 					: ctx.var(this.subject);

--- a/src/query/live.ts
+++ b/src/query/live.ts
@@ -29,6 +29,7 @@ import {
 	type FetchPaths,
 	resolveFetchObject,
 } from "./select.ts";
+import { resolveSubjectSchema } from "./subject.ts";
 import { escapeIdiomPath } from "./utils.ts";
 
 /** The underlying SDK subscription returned by `surreal.liveOf()`. */
@@ -128,7 +129,7 @@ export class LiveQuery<
 	private _fetch?: string[];
 	private _fetchResolvedType?: AbstractType;
 	private _diff = false;
-	private tb: T;
+	private tb: T | readonly T[];
 	private subject: T | RecordId<T> | Workable<C, RecordType<T>>;
 
 	constructor(orm: O, subject: T | RecordId<T> | Workable<C, RecordType<T>>) {
@@ -142,9 +143,10 @@ export class LiveQuery<
 		if (typeof subject === "string") {
 			this.tb = subject;
 		} else if (isWorkable(subject)) {
-			this.tb = subject[__type].tb as T;
+			// A polymorphic link (`t.record(["a", "b"])`) carries an array here.
+			this.tb = (subject[__type] as RecordType<T>).tb;
 		} else {
-			this.tb = String(subject.table) as T;
+			this.tb = String((subject as RecordId<T>).table) as T;
 		}
 	}
 
@@ -153,7 +155,7 @@ export class LiveQuery<
 		// and takes precedence over the fetch-resolved schema.
 		return (this._entry?.[__type] ??
 			this._fetchResolvedType ??
-			this[__ctx].orm.tables[this.tb]!.schema) as E;
+			resolveSubjectSchema(this[__ctx].orm, this.tb)) as E;
 	}
 
 	get [__type](): E {
@@ -205,7 +207,7 @@ export class LiveQuery<
 	): this {
 		const tb = actionable({
 			[__ctx]: this[__ctx],
-			[__type]: this[__ctx].orm.tables[this.tb]!.schema,
+			[__type]: resolveSubjectSchema(this[__ctx].orm, this.tb),
 			[__display]: ({ contextId }) => {
 				return contextId === this[__ctx].id ? "$this" : "$parent";
 			},
@@ -229,7 +231,7 @@ export class LiveQuery<
 		// Reuse SelectQuery's resolved-schema logic so notification values are
 		// validated as the resolved records instead of expecting RecordIds.
 		const currentSchema =
-			this._entry?.[__type] ?? this[__ctx].orm.tables[this.tb]!.schema;
+			this._entry?.[__type] ?? resolveSubjectSchema(this[__ctx].orm, this.tb);
 		const resolved =
 			currentSchema instanceof ObjectType
 				? resolveFetchObject(currentSchema, fields, this[__ctx].orm)
@@ -258,7 +260,8 @@ export class LiveQuery<
 	}
 
 	private displaySubject(ctx: DisplayContext): string {
-		if (typeof this.subject === "string") return ctx.var(new Table(this.tb));
+		if (typeof this.subject === "string")
+			return ctx.var(new Table(this.subject));
 		if (isWorkable(this.subject)) return this.subject[__display](ctx);
 		return ctx.var(this.subject);
 	}

--- a/src/query/select.ts
+++ b/src/query/select.ts
@@ -29,6 +29,7 @@ import {
 	type WorkableContext,
 } from "../utils/workable.ts";
 import { Query } from "./abstract.ts";
+import { type ResolveEntry, resolveSubjectSchema } from "./subject.ts";
 import { escapeIdiomPath } from "./utils.ts";
 
 type FieldKeys<O extends Orm, T extends keyof O["tables"] & string> =
@@ -143,12 +144,20 @@ export class SelectQuery<
 	private _fetch?: string[];
 	private _fetchResolvedType?: AbstractType;
 	private _timeout?: string;
-	private tb: T;
-	private subject: T | RecordId<T> | Workable<C, RecordType<T> | GraphType<T>>;
+	private tb: T | readonly T[];
+	private subject:
+		| T
+		| readonly T[]
+		| RecordId<T>
+		| Workable<C, RecordType<T> | GraphType<T>>;
 
 	constructor(
 		orm: O,
-		subject: T | RecordId<T> | Workable<C, RecordType<T> | GraphType<T>>,
+		subject:
+			| T
+			| readonly T[]
+			| RecordId<T>
+			| Workable<C, RecordType<T> | GraphType<T>>,
 	) {
 		super();
 		this[__ctx] = {
@@ -160,10 +169,16 @@ export class SelectQuery<
 
 		if (typeof subject === "string") {
 			this.tb = subject;
+		} else if (Array.isArray(subject)) {
+			this.tb = subject;
 		} else if (isWorkable(subject)) {
-			this.tb = subject[__type].tb as T;
+			// A polymorphic link (`t.record(["a", "b"])`) carries an array here; an
+			// ordinary link or graph step carries a single table name.
+			this.tb = (subject[__type] as RecordType<T> | GraphType<T>).tb;
 		} else {
-			this.tb = String(subject.table) as T;
+			// `Array.isArray` cannot narrow `readonly T[]` out of the union, so the
+			// remaining case (a RecordId) needs an explicit cast.
+			this.tb = String((subject as RecordId<T>).table) as T;
 		}
 	}
 
@@ -176,7 +191,7 @@ export class SelectQuery<
 		// *before* assigning `_entry`.
 		return (this._entry?.[__type] ??
 			this._fetchResolvedType ??
-			this[__ctx].orm.tables[this.tb]!.schema) as E;
+			resolveSubjectSchema(this[__ctx].orm, this.tb)) as E;
 	}
 
 	get [__type](): ArrayType<E> {
@@ -196,16 +211,22 @@ export class SelectQuery<
 				return contextId === this[__ctx].id ? "$this" : "$parent";
 			},
 		}) as Actionable<C, S>;
-		return traversableRow(base, this[__ctx].orm.tables[this.tb]!.schema.schema);
+		return traversableRow(
+			base,
+			resolveSubjectSchema(this[__ctx].orm, this.tb).schema,
+		);
 	}
 
 	return<
 		P extends Inheritable<C>,
 		R extends InheritableIntoType<C, P> = InheritableIntoType<C, P>,
 	>(
-		cb: (tb: Actionable<C, E> & RowTraversal<C, T>) => P,
+		cb: (tb: Actionable<C, ResolveEntry<E>> & RowTraversal<C, T>) => P,
 	): SelectQuery<O, C, T, R> {
-		const tb = this.rowActionable(this.entry) as Actionable<C, E> &
+		const tb = this.rowActionable(this.entry) as Actionable<
+			C,
+			ResolveEntry<E>
+		> &
 			RowTraversal<C, T>;
 
 		const predicable = cb(tb);
@@ -221,12 +242,14 @@ export class SelectQuery<
 
 	where(
 		cb: (
-			tb: Actionable<C, O["tables"][T]["schema"]> & RowTraversal<C, T>,
+			tb: Actionable<C, ResolveEntry<O["tables"][T]["schema"]>> &
+				RowTraversal<C, T>,
 		) => Workable<C>,
 	) {
 		const tb = this.rowActionable(
-			this[__ctx].orm.tables[this.tb]!.schema,
-		) as Actionable<C, O["tables"][T]["schema"]> & RowTraversal<C, T>;
+			resolveSubjectSchema(this[__ctx].orm, this.tb),
+		) as Actionable<C, ResolveEntry<O["tables"][T]["schema"]>> &
+			RowTraversal<C, T>;
 
 		const filter = sanitizeWorkable(cb(tb));
 		return this.derive((next) => {
@@ -249,7 +272,9 @@ export class SelectQuery<
 	private _addOrderBy(
 		field:
 			| FieldKeys<O, T>
-			| ((record: Actionable<C, E> & RowTraversal<C, T>) => Workable<C>),
+			| ((
+					record: Actionable<C, ResolveEntry<E>> & RowTraversal<C, T>,
+			  ) => Workable<C>),
 		direction?: "ASC" | "DESC",
 		opts?: { collate?: boolean; numeric?: boolean },
 	): this {
@@ -259,7 +284,10 @@ export class SelectQuery<
 				: {
 						field: sanitizeWorkable(
 							field(
-								this.rowActionable(this.entry) as Actionable<C, E> &
+								this.rowActionable(this.entry) as Actionable<
+									C,
+									ResolveEntry<E>
+								> &
 									RowTraversal<C, T>,
 							),
 						),
@@ -274,7 +302,9 @@ export class SelectQuery<
 	orderBy(
 		field:
 			| FieldKeys<O, T>
-			| ((record: Actionable<C, E> & RowTraversal<C, T>) => Workable<C>),
+			| ((
+					record: Actionable<C, ResolveEntry<E>> & RowTraversal<C, T>,
+			  ) => Workable<C>),
 		direction?: "ASC" | "DESC",
 	): this {
 		return this._addOrderBy(field, direction);
@@ -283,7 +313,9 @@ export class SelectQuery<
 	orderByNumeric(
 		field:
 			| FieldKeys<O, T>
-			| ((record: Actionable<C, E> & RowTraversal<C, T>) => Workable<C>),
+			| ((
+					record: Actionable<C, ResolveEntry<E>> & RowTraversal<C, T>,
+			  ) => Workable<C>),
 		direction?: "ASC" | "DESC",
 	): this {
 		return this._addOrderBy(field, direction, { numeric: true });
@@ -292,7 +324,9 @@ export class SelectQuery<
 	orderByCollate(
 		field:
 			| FieldKeys<O, T>
-			| ((record: Actionable<C, E> & RowTraversal<C, T>) => Workable<C>),
+			| ((
+					record: Actionable<C, ResolveEntry<E>> & RowTraversal<C, T>,
+			  ) => Workable<C>),
 		direction?: "ASC" | "DESC",
 	): this {
 		return this._addOrderBy(field, direction, { collate: true });
@@ -325,7 +359,7 @@ export class SelectQuery<
 		// RecordIds. SurrealDB expands every record along a fetched path, so
 		// `out.author` resolves both `out` and its nested `author`.
 		const currentSchema =
-			this._entry?.[__type] ?? this[__ctx].orm.tables[this.tb]!.schema;
+			this._entry?.[__type] ?? resolveSubjectSchema(this[__ctx].orm, this.tb);
 		const resolved =
 			currentSchema instanceof ObjectType
 				? resolveFetchObject(currentSchema, fields, this[__ctx].orm)
@@ -344,9 +378,12 @@ export class SelectQuery<
 	}
 
 	private displaySubject(ctx: DisplayContext): string {
-		if (typeof this.subject === "string") return ctx.var(new Table(this.tb));
+		if (typeof this.subject === "string")
+			return ctx.var(new Table(this.subject));
+		if (Array.isArray(this.subject))
+			return this.subject.map((name) => ctx.var(new Table(name))).join(", ");
 		if (isWorkable(this.subject)) return this.subject[__display](ctx);
-		return ctx.var(this.subject);
+		return ctx.var(this.subject as RecordId<T>);
 	}
 
 	private displayOrderBy(ctx: DisplayContext): string {

--- a/src/query/subject.ts
+++ b/src/query/subject.ts
@@ -1,0 +1,120 @@
+import type { Orm } from "../schema/orm.ts";
+import {
+	type AbstractType,
+	ObjectType,
+	type ObjectTypeInner,
+	OptionType,
+	UnionType,
+} from "../types";
+
+/** Every key across a union of field maps (union, not the `keyof` intersection). */
+type AllKeys<F> = F extends unknown ? keyof F : never;
+
+/** Whether `K` is present in *every* member of the field-map union `F`. */
+type PresentInAll<F, K extends PropertyKey> = F extends unknown
+	? K extends keyof F
+		? true
+		: false
+	: never;
+
+/** The union of `F[K]` across every member of `F` that defines `K`. */
+type Collect<F, K extends PropertyKey> = F extends unknown
+	? K extends keyof F
+		? F[K]
+		: never
+	: never;
+
+/**
+ * Merge a union of field maps into one: fields present in every member keep
+ * their (possibly unioned) type, fields missing from some member become
+ * `option<…>`. Mirrors the runtime {@link mergeSchemas}.
+ */
+type MergeFields<F extends ObjectTypeInner> = {
+	[K in AllKeys<F>]: false extends PresentInAll<F, K>
+		? OptionType<Collect<F, K> & AbstractType>
+		: Collect<F, K> & AbstractType;
+};
+
+/**
+ * The row shape a select rooted at `S` exposes. For a single-table schema this
+ * is effectively the schema itself (a one-member merge collapses to identity);
+ * for a union of member schemas (multi-table / polymorphic-link select) the
+ * members are merged into one `ObjectType` via {@link MergeFields}, mirroring
+ * the runtime {@link resolveSubjectSchema}.
+ *
+ * The merge is written as a single, non-distributive `[S] extends
+ * [ObjectType<infer F>]` so it stays lazy: an `IsUnion`-style probe would force
+ * TypeScript to materialise `this["tables"]` at the `orm.select` call sites,
+ * which trips the invariant-`Orm` constraint on the polymorphic `this` type.
+ */
+export type ResolveEntry<S extends AbstractType> = [S] extends [
+	ObjectType<infer F>,
+]
+	? ObjectType<MergeFields<F>>
+	: S;
+
+/**
+ * Resolve a query builder's stored table — which is a single table name for an
+ * ordinary select, or an array of names for a multi-table / polymorphic-link
+ * select (`t.record(["user", "org"])`, `db.select(["user", "company"])`) — into
+ * the `ObjectType` that describes a row.
+ *
+ * For a single table this is just the table's schema. For multiple tables the
+ * member schemas are {@link mergeSchemas | merged} into one row type so a single
+ * projection callback can reach every field; see {@link mergeSchemas} for how
+ * total and partial fields are combined.
+ */
+export function resolveSubjectSchema(
+	orm: Orm,
+	tb: string | readonly string[],
+): ObjectType {
+	const tables = orm.tables as Record<string, { schema: ObjectType }>;
+	if (typeof tb === "string") return tables[tb]!.schema;
+	return mergeSchemas(tb.map((name) => tables[name]!.schema));
+}
+
+/**
+ * Merge several table schemas into a single row `ObjectType`:
+ * - a field present in **every** member keeps its type — collapsing to a single
+ *   type when the members agree, or a {@link UnionType} when they diverge
+ *   (e.g. `id` is `RecordId<"user">` on one table and `RecordId<"company">` on
+ *   another);
+ * - a field present in only **some** members is wrapped in an {@link OptionType}
+ *   (`option<…>` → `T | undefined`), because SurrealDB returns `NONE` for that
+ *   field on rows whose table does not define it.
+ */
+function mergeSchemas(members: ObjectType[]): ObjectType {
+	const occurrences = new Map<string, AbstractType[]>();
+	for (const member of members) {
+		for (const [key, type] of Object.entries(member.schema)) {
+			const list = occurrences.get(key);
+			if (list) list.push(type);
+			else occurrences.set(key, [type]);
+		}
+	}
+
+	const fields: Record<string, AbstractType> = {};
+	for (const [key, types] of occurrences) {
+		const distinct = dedupeByExpected(types);
+		let type: AbstractType =
+			distinct.length === 1 ? distinct[0]! : new UnionType(distinct);
+		// Missing from at least one member → optional.
+		if (types.length < members.length) type = new OptionType(type);
+		fields[key] = type;
+	}
+
+	return new ObjectType(fields);
+}
+
+/** Collapse types whose `expected` descriptor is identical (e.g. two `string`s). */
+function dedupeByExpected(types: AbstractType[]): AbstractType[] {
+	const seen = new Set<string>();
+	const result: AbstractType[] = [];
+	for (const type of types) {
+		const key = JSON.stringify(type.expected);
+		if (seen.has(key)) continue;
+		seen.add(key);
+		result.push(type);
+	}
+	return result;
+}

--- a/src/query/update.ts
+++ b/src/query/update.ts
@@ -37,6 +37,7 @@ import {
 	type ModificationState,
 	type SetData,
 } from "./modification-methods.ts";
+import { resolveSubjectSchema } from "./subject.ts";
 
 /**
  * A fluent UPDATE query builder. Supports SET, UNSET, CONTENT, MERGE, PATCH,
@@ -62,7 +63,7 @@ export class UpdateQuery<
 	private _filter?: Workable<C>;
 	private _return?: "none" | "before" | "after" | "diff" | Workable<C, E>;
 	private _timeout?: string;
-	private tb: T;
+	private tb: T | readonly T[];
 	private subject: T | RecordId<T> | Workable<C, RecordType<T>>;
 
 	constructor(orm: O, subject: T | RecordId<T> | Workable<C, RecordType<T>>) {
@@ -77,14 +78,15 @@ export class UpdateQuery<
 		if (typeof subject === "string") {
 			this.tb = subject;
 		} else if (isWorkable(subject)) {
-			this.tb = subject[__type].tb as T;
+			// A polymorphic link (`t.record(["a", "b"])`) carries an array here.
+			this.tb = (subject[__type] as RecordType<T>).tb;
 		} else {
-			this.tb = String(subject.table) as T;
+			this.tb = String((subject as RecordId<T>).table) as T;
 		}
 	}
 
 	get schema(): E {
-		return this[__ctx].orm.tables[this.tb]!.schema as unknown as E;
+		return resolveSubjectSchema(this[__ctx].orm, this.tb) as unknown as E;
 	}
 
 	get [__type](): ArrayType<E> {
@@ -123,7 +125,7 @@ export class UpdateQuery<
 	where(cb: (tb: Actionable<C, O["tables"][T]["schema"]>) => Workable<C>) {
 		const tb = actionable({
 			[__ctx]: this[__ctx],
-			[__type]: this[__ctx].orm.tables[this.tb]!.schema,
+			[__type]: resolveSubjectSchema(this[__ctx].orm, this.tb),
 			[__display]: ({ contextId }) => {
 				return contextId === this[__ctx].id ? "$this" : "$parent";
 			},
@@ -187,7 +189,7 @@ export class UpdateQuery<
 
 		const thing =
 			typeof this.subject === "string"
-				? ctx.var(new Table(this.tb))
+				? ctx.var(new Table(this.subject))
 				: isWorkable(this.subject)
 					? this.subject[__display](ctx)
 					: ctx.var(this.subject);

--- a/src/query/upsert.ts
+++ b/src/query/upsert.ts
@@ -36,6 +36,7 @@ import {
 	type ModificationState,
 	type SetData,
 } from "./modification-methods.ts";
+import { resolveSubjectSchema } from "./subject.ts";
 
 /**
  * A fluent UPSERT query builder. Creates the record if it doesn't exist, or
@@ -61,7 +62,7 @@ export class UpsertQuery<
 	private _filter?: Workable<C>;
 	private _return?: "none" | "before" | "after" | "diff" | Workable<C, E>;
 	private _timeout?: string;
-	private tb: T;
+	private tb: T | readonly T[];
 	private subject: T | RecordId<T> | Workable<C, RecordType<T>>;
 
 	constructor(orm: O, subject: T | RecordId<T> | Workable<C, RecordType<T>>) {
@@ -76,14 +77,15 @@ export class UpsertQuery<
 		if (typeof subject === "string") {
 			this.tb = subject;
 		} else if (isWorkable(subject)) {
-			this.tb = subject[__type].tb as T;
+			// A polymorphic link (`t.record(["a", "b"])`) carries an array here.
+			this.tb = (subject[__type] as RecordType<T>).tb;
 		} else {
-			this.tb = String(subject.table) as T;
+			this.tb = String((subject as RecordId<T>).table) as T;
 		}
 	}
 
 	get schema(): E {
-		return this[__ctx].orm.tables[this.tb]!.schema as unknown as E;
+		return resolveSubjectSchema(this[__ctx].orm, this.tb) as unknown as E;
 	}
 
 	get [__type](): ArrayType<E> {
@@ -118,7 +120,7 @@ export class UpsertQuery<
 	where(cb: (tb: Actionable<C, O["tables"][T]["schema"]>) => Workable<C>) {
 		const tb = actionable({
 			[__ctx]: this[__ctx],
-			[__type]: this[__ctx].orm.tables[this.tb]!.schema,
+			[__type]: resolveSubjectSchema(this[__ctx].orm, this.tb),
 			[__display]: ({ contextId }) => {
 				return contextId === this[__ctx].id ? "$this" : "$parent";
 			},
@@ -182,7 +184,7 @@ export class UpsertQuery<
 
 		const thing =
 			typeof this.subject === "string"
-				? ctx.var(new Table(this.tb))
+				? ctx.var(new Table(this.subject))
 				: isWorkable(this.subject)
 					? this.subject[__display](ctx)
 					: ctx.var(this.subject);

--- a/src/schema/orm.ts
+++ b/src/schema/orm.ts
@@ -205,6 +205,13 @@ export class Orm<T extends AnyTable[] = AnyTable[]> {
 		Tb extends keyof this["tables"] & string,
 	>(tb: Tb): SelectQuery<this, C, Tb>;
 
+	// Multiple tables — a heterogeneous select whose rows are the merged schema
+	// of every named table (`SELECT … FROM user, company`).
+	select<
+		C extends WorkableContext<this>,
+		const Tb extends keyof this["tables"] & string,
+	>(tbs: readonly Tb[]): SelectQuery<this, C, Tb>;
+
 	// RecordId
 	select<
 		C extends WorkableContext<this>,
@@ -229,10 +236,15 @@ export class Orm<T extends AnyTable[] = AnyTable[]> {
 		C extends WorkableContext<this>,
 		Tb extends keyof this["tables"] & string,
 	>(
-		tb: Tb | RecordId<Tb> | Workable<C, RecordType<Tb> | GraphType<Tb>>,
+		tb:
+			| Tb
+			| readonly Tb[]
+			| RecordId<Tb>
+			| Workable<C, RecordType<Tb> | GraphType<Tb>>,
 		id?: RecordIdValue,
 	) {
 		if (tb instanceof RecordId) return new SelectQuery(this, tb);
+		if (Array.isArray(tb)) return new SelectQuery(this, tb as readonly Tb[]);
 		if (isWorkable(tb))
 			return new SelectQuery(this, tb as Workable<C, RecordType<Tb>>);
 		if (id === undefined) return new SelectQuery(this, tb as Tb);

--- a/tests/unit/query/polymorphic-select.test.ts
+++ b/tests/unit/query/polymorphic-select.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from "bun:test";
+import { RecordId, Surreal, Table } from "surrealdb";
+import { __display, displayContext, orm, t, table } from "../../../src";
+import { resolveSubjectSchema } from "../../../src/query/subject.ts";
+
+// Compile-time equality assertion helper.
+type Equal<A, B> =
+	(<G>() => G extends A ? 1 : 2) extends <G>() => G extends B ? 1 : 2
+		? true
+		: false;
+
+const render = (q: {
+	[__display]: (ctx: ReturnType<typeof displayContext>) => string;
+}) => q[__display](displayContext());
+
+const user = table("user", {
+	name: t.string(),
+	age: t.number(),
+	born: t.date(),
+});
+const company = table("company", { name: t.string(), founded: t.date() });
+const file = table("file", {
+	name: t.string(),
+	owner: t.record(["user", "company"]),
+});
+const db = orm(new Surreal(), user, company, file);
+
+describe("polymorphic / multi-table SELECT", () => {
+	test("polymorphic record-link .select() no longer crashes (regression)", () => {
+		const q = db.select("file").return((f) => ({
+			name: f.name,
+			owner: f.owner.select().return((o) => ({ name: o.name })),
+		}));
+
+		// Previously threw `TypeError: undefined is not an object` because the
+		// builder dereferenced `orm.tables[["user","company"]]`.
+		const sql = render(q);
+		expect(sql).toContain("FROM $parent.owner");
+
+		type R = t.infer<typeof q>;
+		const _check: Equal<R, { name: string; owner: { name: string }[] }[]> =
+			true;
+		expect(_check).toBe(true);
+	});
+
+	test("top-level multi-table select renders FROM user, company", () => {
+		const q = db.select(["user", "company"]).return((o) => ({ name: o.name }));
+		const ctx = displayContext();
+		const sql = q[__display](ctx);
+
+		expect(sql).toMatch(/FROM \$\w+, \$\w+/);
+		expect(Object.values(ctx.variables)).toContainEqual(new Table("user"));
+		expect(Object.values(ctx.variables)).toContainEqual(new Table("company"));
+	});
+
+	test("partial fields are optional; common fields stay required", () => {
+		const q = db.select(["user", "company"]).return((o) => ({
+			name: o.name, // present in both → string
+			age: o.age, //   user only      → number | undefined
+			born: o.born, // user only      → Date | undefined
+		}));
+
+		type R = t.infer<typeof q>;
+		const _check: Equal<
+			R,
+			{ name: string; age: number | undefined; born: Date | undefined }[]
+		> = true;
+		expect(_check).toBe(true);
+	});
+
+	test("a field whose type differs across tables becomes a field-level union", () => {
+		const q = db.select(["user", "company"]).return((o) => ({
+			name: o.name,
+			ref: o.id, // RecordId<"user"> on user, RecordId<"company"> on company
+		}));
+
+		type R = t.infer<typeof q>;
+		const _check: Equal<
+			R,
+			{ name: string; ref: RecordId<"user"> | RecordId<"company"> }[]
+		> = true;
+		expect(_check).toBe(true);
+	});
+
+	test("a member-specific field is reachable as an optional", () => {
+		// Unlike a plain union (which exposes only common fields), the merged row
+		// exposes every member's fields; ones missing from some member are optional.
+		const q = db.select(["user", "company"]).return((o) => ({
+			founded: o.founded, // company only → Date | undefined
+		}));
+		type R = t.infer<typeof q>;
+		const _check: Equal<R, { founded: Date | undefined }[]> = true;
+		expect(_check).toBe(true);
+	});
+
+	test("single-table select is unchanged — no spurious | undefined", () => {
+		const q = db.select("user").return((o) => ({ name: o.name, age: o.age }));
+		type R = t.infer<typeof q>;
+		const _check: Equal<R, { name: string; age: number }[]> = true;
+		expect(_check).toBe(true);
+	});
+});
+
+describe("resolveSubjectSchema — runtime schema merge", () => {
+	test("merges member schemas: common, partial, and divergent fields", () => {
+		const merged = resolveSubjectSchema(db, ["user", "company"]);
+		const fields = merged.schema;
+
+		// present in both with the same type → kept as-is
+		expect(fields.name!.name).toBe("string");
+		// present in only one member → wrapped in option<…>
+		expect(fields.age!.name).toBe("option");
+		expect(fields.born!.name).toBe("option");
+		expect(fields.founded!.name).toBe("option");
+		// present in both but divergent (id: user vs company) → union
+		expect(fields.id!.name).toBe("union");
+	});
+
+	test("a single table resolves to its own schema", () => {
+		const merged = resolveSubjectSchema(db, "user");
+		expect(merged).toEqual(db.tables.user.schema);
+	});
+
+	test("parses a company row's missing fields to undefined (SurrealDB NONE)", () => {
+		const merged = resolveSubjectSchema(db, ["user", "company"]);
+		const parsed = merged.parse({
+			id: new RecordId("company", "acme"),
+			name: "Acme",
+			founded: new Date("2000-01-01"),
+		});
+
+		// `age` and `born` are user-only, so they are absent on a company row and
+		// resolve to `undefined` rather than throwing.
+		expect(parsed.name).toBe("Acme");
+		expect(parsed.age).toBeUndefined();
+		expect(parsed.born).toBeUndefined();
+		expect(parsed.founded).toBeInstanceOf(Date);
+	});
+});


### PR DESCRIPTION
Fixes the polymorphic record-link select crash (review item #5 of #35) and makes a select rooted at multiple tables usable.

> [!NOTE]
> Targets `micha/improve` (the #35 branch), not `main`: multi-table record links — and therefore this bug — only exist on #35. Rebase onto `main` once #35 lands.

## The bug
`RecordType.tb` is now `T | readonly T[]`. For a polymorphic link (`t.record(["user","org"])`) the runtime value is an array, but `this.tb = subject[__type].tb as T` hid that from the compiler. Every builder's `entry`/`schema` getter then did `orm.tables[["user","org"]]` → `undefined` → `TypeError`. Repro (compiled clean, crashed at runtime):

```ts
db.select("file").return((f) => ({
  name: f.name,
  owner: f.owner.select().return((o) => ({ name: o.name })), // owner: t.record(["user","org"])
}));
```

## The model: merged-optional row
A row rooted at multiple tables (a polymorphic link, or the new top-level `db.select(["user","company"])`) is typed and parsed as a single **merged** `ObjectType`:

- a field in **every** member keeps its type (a union when members diverge, e.g. `id`);
- a field in only **some** members becomes `option<…>` → `T | undefined` (SurrealDB returns `NONE` for it on rows whose table lacks the field).

So one `.return()` callback can project any member's fields:

```ts
db.select(["user","company"]).return((o) => ({
  name: o.name,   // in both    → string
  age:  o.age,    // user only  → number | undefined
  born: o.born,   // user only  → Date | undefined
}));
// → { name: string; age: number | undefined; born: Date | undefined }[]
// SQL: SELECT VALUE { … } FROM user, company
```

Out of scope: true per-variant output discrimination (`{…user} | {…company}` projecting different fields per table) — needs a separate per-variant-callback API.

## Implementation
- **new `src/query/subject.ts`** — runtime `resolveSubjectSchema` (merge: `UnionType` for divergent total fields, `OptionType` for partial) + the compile-time `ResolveEntry` mirror.
- **all 5 builders** (`select`/`update`/`delete`/`upsert`/`live`) — widen `tb` to `T | readonly T[]`, drop the unsafe `as T`, resolve schema via `resolveSubjectSchema`.
- **`orm.select`** — new `readonly Tb[]` overload + `FROM a, b` rendering.
- `ResolveEntry` lives in the callback param types (not the class `E` default) and is written non-distributively so it stays lazy. An eager/`IsUnion`-style probe forces TS to materialise `this["tables"]` at the `orm.select` call sites, which trips the invariant-`Orm` constraint on the polymorphic `this` (~50 errors). Single-table selects are unchanged.

## Verify
- `npx tsc --noEmit` clean
- `bun test tests/unit` — 616 pass (9 new in `tests/unit/query/polymorphic-select.test.ts`: regression repro, `FROM user, company`, partial→optional types, divergent-field union, single-table identity, runtime merge + NONE→undefined parse)
- `biome check .` clean
- Integration tests need a live DB; not run here