### PR TITLE
Resolve field access through record links, options, and arrays

### DIFF
--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -34,6 +34,10 @@ export type GetFunctions<
 	C extends WorkableContext,
 	T extends AbstractType,
 > = BaseFunctions["any"] &
+	// An `option<T>` exposes only its own `option` functions (`map`, `unwrap`, …).
+	// Field/index access through the option resolves transparently (see
+	// `ActionableProps`); to call a *type-specific* method on the inner value
+	// (e.g. `.at()` on an `option<array>`), `unwrap()` it first.
 	(T["name"] extends keyof BaseFunctions
 		? BaseFunctions[T["name"]]
 		: Record<

--- a/src/functions/types/array.ts
+++ b/src/functions/types/array.ts
@@ -4,10 +4,10 @@ import {
 	type BoolType,
 	type LiteralType,
 	type NumberType,
-	type OptionType,
+	OptionType,
 	type StringType,
 	t,
-	type UnionType,
+	UnionType,
 } from "../../types";
 import {
 	__ctx,
@@ -21,6 +21,12 @@ import type { Actionable } from "../../utils/actionable";
 import type { At } from "../../utils/types";
 import { comparingFilter } from "../filters";
 import { databaseFunction } from "../utils";
+
+/** The element type of an array: the single schema, or a union for a tuple. */
+function elementType(arr: ArrayType): AbstractType {
+	const schema = arr.schema;
+	return Array.isArray(schema) ? new UnionType(schema) : schema;
+}
 
 export const functions = {
 	// Contains
@@ -822,7 +828,12 @@ function at<C extends WorkableContext, T extends AbstractType>(
 	n: IntoWorkable<C, NumberType>,
 ) {
 	const v = intoWorkable(this[__ctx], t.number(), n);
-	return databaseFunction(this[__ctx], this[__type], "array::at", this, v);
+	// `array::at` yields the element (or NONE when out of bounds), not the array,
+	// so further field access resolves against the element type — see issue #36.
+	const element = elementType(this[__type]);
+	const type =
+		element instanceof OptionType ? element : new OptionType(element);
+	return databaseFunction(this[__ctx], type, "array::at", this, v);
 }
 
 function val<C extends WorkableContext, T extends AbstractType[]>(

--- a/src/functions/types/option.ts
+++ b/src/functions/types/option.ts
@@ -1,8 +1,15 @@
-import { type AbstractType, type OptionType, t } from "../../types";
+import {
+	type AbstractType,
+	type BoolType,
+	type OptionType,
+	t,
+} from "../../types";
 import {
 	__ctx,
 	__display,
 	__type,
+	type IntoWorkable,
+	intoWorkable,
 	type Workable,
 	type WorkableContext,
 } from "../../utils";
@@ -23,12 +30,94 @@ export const functions = {
 			[__display]: this[__display],
 		});
 		const res = cb(inner);
+		// NB: arrow display — a method-shorthand `[__display](ctx){}` would rebind
+		// `this` to the new workable and recurse on `this[__display]`.
 		return actionable({
 			[__ctx]: this[__ctx],
 			[__type]: t.option(res[__type]),
-			[__display](ctx) {
-				return `(${this[__display](ctx)}?${res[__display](ctx)})`;
-			},
+			[__display]: (ctx) => `(${this[__display](ctx)}?${res[__display](ctx)})`,
+		});
+	},
+
+	/**
+	 * Treat the value as its non-optional inner type, exposing the inner type's
+	 * fields and methods for chaining. SurrealDB dereferences a `NONE` to `NONE`
+	 * transparently, so this is an identity on the rendered path — it only sheds
+	 * the `option<…>` wrapper at the type level (the query stays NONE-safe). Use
+	 * it to call inner methods that the `option` itself doesn't expose, e.g.
+	 * `tags.unwrap().at(0)` or `link.unwrap().select()`.
+	 */
+	unwrap<C extends WorkableContext, T extends AbstractType>(
+		this: Workable<C, OptionType<T>>,
+	) {
+		return actionable({
+			[__ctx]: this[__ctx],
+			[__type]: this[__type].schema,
+			[__display]: this[__display],
+		});
+	},
+
+	/**
+	 * Supply a fallback for when the value is absent: renders `(<value> ?? <fallback>)`
+	 * using SurrealDB's null-coalescing operator, yielding the non-optional inner
+	 * type. The Rust `Option::unwrap_or` equivalent (`unwrap_or_else` collapses to
+	 * this too — a query fallback is just an expression, with no laziness).
+	 */
+	unwrapOr<C extends WorkableContext, T extends AbstractType>(
+		this: Workable<C, OptionType<T>>,
+		fallback: IntoWorkable<C, T>,
+	) {
+		const value = intoWorkable(this[__ctx], this[__type].schema, fallback);
+		return actionable({
+			[__ctx]: this[__ctx],
+			[__type]: this[__type].schema,
+			[__display]: (ctx) =>
+				`(${this[__display](ctx)} ?? ${value[__display](ctx)})`,
+		});
+	},
+
+	/** `<value> IS NONE` — true when the value is absent. */
+	isNone<C extends WorkableContext, T extends AbstractType>(
+		this: Workable<C, OptionType<T>>,
+	) {
+		return actionable({
+			[__ctx]: this[__ctx],
+			[__type]: t.bool(),
+			[__display]: (ctx) => `${this[__display](ctx)} IS NONE`,
+		});
+	},
+
+	/** `<value> IS NOT NONE` — true when the value is present. */
+	isSome<C extends WorkableContext, T extends AbstractType>(
+		this: Workable<C, OptionType<T>>,
+	) {
+		return actionable({
+			[__ctx]: this[__ctx],
+			[__type]: t.bool(),
+			[__display]: (ctx) => `${this[__display](ctx)} IS NOT NONE`,
+		});
+	},
+
+	/**
+	 * Present *and* the inner value satisfies `cb` — renders
+	 * `(<value> IS NOT NONE AND <cb(inner)>)`. The Rust `Option::is_some_and`
+	 * equivalent; the callback receives the unwrapped inner value.
+	 */
+	isSomeAnd<C extends WorkableContext, T extends AbstractType>(
+		this: Workable<C, OptionType<T>>,
+		cb: (value: Actionable<C, T>) => Workable<C, BoolType>,
+	) {
+		const inner = actionable({
+			[__ctx]: this[__ctx],
+			[__type]: this[__type].schema,
+			[__display]: this[__display],
+		});
+		const pred = cb(inner);
+		return actionable({
+			[__ctx]: this[__ctx],
+			[__type]: t.bool(),
+			[__display]: (ctx) =>
+				`(${this[__display](ctx)} IS NOT NONE AND ${pred[__display](ctx)})`,
 		});
 	},
 } satisfies Functions;
@@ -42,4 +131,26 @@ export type Functions = {
 		this: Workable<C, OptionType<T>>,
 		cb: (arg: Actionable<C, T>) => Workable<C, R>,
 	): Actionable<C, OptionType<R>>;
+
+	unwrap<C extends WorkableContext, T extends AbstractType>(
+		this: Workable<C, OptionType<T>>,
+	): Actionable<C, T>;
+
+	unwrapOr<C extends WorkableContext, T extends AbstractType>(
+		this: Workable<C, OptionType<T>>,
+		fallback: IntoWorkable<C, T>,
+	): Actionable<C, T>;
+
+	isNone<C extends WorkableContext, T extends AbstractType>(
+		this: Workable<C, OptionType<T>>,
+	): Actionable<C, BoolType>;
+
+	isSome<C extends WorkableContext, T extends AbstractType>(
+		this: Workable<C, OptionType<T>>,
+	): Actionable<C, BoolType>;
+
+	isSomeAnd<C extends WorkableContext, T extends AbstractType>(
+		this: Workable<C, OptionType<T>>,
+		cb: (value: Actionable<C, T>) => Workable<C, BoolType>,
+	): Actionable<C, BoolType>;
 };

--- a/src/query/select.ts
+++ b/src/query/select.ts
@@ -16,6 +16,7 @@ import { type DisplayContext, displayContext } from "../utils/display.ts";
 import {
 	type Inheritable,
 	type InheritableIntoType,
+	type InheritableObject,
 	inheritableIntoWorkable,
 } from "../utils/inheritable.ts";
 import { traversableRow } from "../utils/traversal.ts";
@@ -36,6 +37,29 @@ type FieldKeys<O extends Orm, T extends keyof O["tables"] & string> =
 	O["tables"][T]["schema"] extends ObjectType<infer F>
 		? keyof F & string
 		: string;
+
+/**
+ * The `.extend({ … })` method exposed on the `.return()` row: it projects every
+ * field of the row, merged with (and overridden by) the given computed fields,
+ * returning a single object projection — see issue #39. `RE` is the row's
+ * resolved entry `ObjectType`, so its fields carry through with their declared
+ * types and the caller's keys take precedence.
+ */
+type RowExtend<C extends WorkableContext, RE extends AbstractType> =
+	RE extends ObjectType<infer F>
+		? {
+				extend<Ex extends InheritableObject<C>>(
+					extra: Ex,
+				): Workable<
+					C,
+					ObjectType<
+						Omit<F, keyof Ex> & {
+							[K in keyof Ex]: InheritableIntoType<C, Ex[K]>;
+						}
+					>
+				>;
+			}
+		: { extend(extra: InheritableObject<C>): Workable<C, ObjectType> };
 
 /**
  * Every valid FETCH path for a table: a top-level field, or a dotted path
@@ -221,13 +245,18 @@ export class SelectQuery<
 		P extends Inheritable<C>,
 		R extends InheritableIntoType<C, P> = InheritableIntoType<C, P>,
 	>(
-		cb: (tb: Actionable<C, ResolveEntry<E>> & RowTraversal<C, T>) => P,
+		cb: (
+			tb: Actionable<C, ResolveEntry<E>> &
+				RowTraversal<C, T> &
+				RowExtend<C, ResolveEntry<E>>,
+		) => P,
 	): SelectQuery<O, C, T, R> {
 		const tb = this.rowActionable(this.entry) as Actionable<
 			C,
 			ResolveEntry<E>
 		> &
-			RowTraversal<C, T>;
+			RowTraversal<C, T> &
+			RowExtend<C, ResolveEntry<E>>;
 
 		const predicable = cb(tb);
 		const workable = inheritableIntoWorkable<C, P>(

--- a/src/query/subject.ts
+++ b/src/query/subject.ts
@@ -29,7 +29,7 @@ type Collect<F, K extends PropertyKey> = F extends unknown
  * their (possibly unioned) type, fields missing from some member become
  * `option<…>`. Mirrors the runtime {@link mergeSchemas}.
  */
-type MergeFields<F extends ObjectTypeInner> = {
+export type MergeFields<F extends ObjectTypeInner> = {
 	[K in AllKeys<F>]: false extends PresentInAll<F, K>
 		? OptionType<Collect<F, K> & AbstractType>
 		: Collect<F, K> & AbstractType;
@@ -83,7 +83,7 @@ export function resolveSubjectSchema(
  *   (`option<…>` → `T | undefined`), because SurrealDB returns `NONE` for that
  *   field on rows whose table does not define it.
  */
-function mergeSchemas(members: ObjectType[]): ObjectType {
+export function mergeSchemas(members: ObjectType[]): ObjectType {
 	const occurrences = new Map<string, AbstractType[]>();
 	for (const member of members) {
 		for (const [key, type] of Object.entries(member.schema)) {

--- a/src/utils/actionable.ts
+++ b/src/utils/actionable.ts
@@ -1,5 +1,6 @@
 import { OrmError } from "../error";
 import { type GetFunctions, getFunctions } from "../functions";
+import type { MergeFields } from "../query/subject.ts";
 import type { TableFieldsOf } from "../schema/traversal";
 import type {
 	AbstractType,
@@ -7,33 +8,68 @@ import type {
 	GraphType,
 	ObjectType,
 	OptionType,
+	RecordType,
 	StringType,
 	UnionType,
 } from "../types";
 import { type Workable, type WorkableContext, workableGet } from "./workable";
 
+/**
+ * The merged field map a record link `record<Tb>` exposes for property access:
+ * a single table's fields, or the {@link MergeFields | merged} fields of a
+ * multi-table link (`record<"a" | "b">`). Mirrors the runtime resolution in
+ * `workableGet`'s `resolveAccessType`.
+ */
+type RecordFields<C extends WorkableContext, Tb extends string> =
+	TableFieldsOf<C, Tb> extends ObjectType<infer O> ? MergeFields<O> : never;
+
+/** Field props for an `option<Inner>`: like `Inner`'s, but each kept optional. */
+type OptionalProps<C extends WorkableContext, Inner extends AbstractType> =
+	Inner extends ObjectType<infer O>
+		? { [K in keyof O]: Actionable<C, OptionType<O[K] & AbstractType>> }
+		: [Inner] extends [RecordType<infer Tb extends string>]
+			? {
+					[K in keyof RecordFields<C, Tb>]: Actionable<
+						C,
+						OptionType<RecordFields<C, Tb>[K] & AbstractType>
+					>;
+				}
+			: // arrays already yield optional elements; scalars have no props
+				ActionableProps<C, Inner>;
+
 export type ActionableProps<C extends WorkableContext, T extends AbstractType> =
-	T extends ObjectType<infer O>
-		? { [K in keyof O]: Actionable<C, O[K]> }
-		: T extends GraphType<infer Tb>
-			? TableFieldsOf<C, Tb> extends ObjectType<infer O>
-				? { [K in keyof O]: Actionable<C, ArrayType<O[K]>> }
-				: unknown
-			: T extends ArrayType<infer A>
-				? A extends AbstractType
-					? {
-							[K: number]: Actionable<C, OptionType<A>>;
-						}
-					: A extends AbstractType[]
-						? {
-								[K in keyof A as K extends keyof unknown[]
-									? never
-									: K]: A[K] extends AbstractType ? Actionable<C, A[K]> : never;
-							} & {
-								[K: number]: Actionable<C, OptionType<UnionType<A>>>;
-							}
-						: never
-				: unknown;
+	T extends OptionType<infer Inner>
+		? OptionalProps<C, Inner>
+		: T extends ObjectType<infer O>
+			? { [K in keyof O]: Actionable<C, O[K]> }
+			: [T] extends [RecordType<infer Tb extends string>]
+				? {
+						[K in keyof RecordFields<C, Tb>]: Actionable<
+							C,
+							RecordFields<C, Tb>[K] & AbstractType
+						>;
+					}
+				: T extends GraphType<infer Tb>
+					? TableFieldsOf<C, Tb> extends ObjectType<infer O>
+						? { [K in keyof O]: Actionable<C, ArrayType<O[K]>> }
+						: unknown
+					: T extends ArrayType<infer A>
+						? A extends AbstractType
+							? {
+									[K: number]: Actionable<C, OptionType<A>>;
+								}
+							: A extends AbstractType[]
+								? {
+										[K in keyof A as K extends keyof unknown[]
+											? never
+											: K]: A[K] extends AbstractType
+											? Actionable<C, A[K]>
+											: never;
+									} & {
+										[K: number]: Actionable<C, OptionType<UnionType<A>>>;
+									}
+								: never
+						: unknown;
 
 export type Actionable<
 	C extends WorkableContext,

--- a/src/utils/traversal.ts
+++ b/src/utils/traversal.ts
@@ -1,6 +1,11 @@
 import type { AbstractType } from "../types";
 import type { Actionable } from "./actionable";
-import type { WorkableContext } from "./workable";
+import {
+	type Inheritable,
+	type InheritableObject,
+	inheritableIntoWorkable,
+} from "./inheritable";
+import type { Workable, WorkableContext } from "./workable";
 
 /** Traversal verbs that the row sugar exposes by delegating to the row's `id`. */
 const TRAVERSAL_VERBS = new Set(["out", "in", "both"]);
@@ -20,6 +25,21 @@ export function traversableRow<
 >(row: Actionable<C, T>, fields: Record<string, unknown>): Actionable<C, T> {
 	return new Proxy(row, {
 		get(target, prop) {
+			// `row.extend({ … })` projects every field of the row plus (or
+			// overriding with) the given computed fields — see issue #39. The
+			// caller's keys win over the spread fields via assign order.
+			if (prop === "extend") {
+				return (extra: InheritableObject<C>) => {
+					const merged: Record<string, Inheritable<C>> = {};
+					const row = target as unknown as Record<string, Inheritable<C>>;
+					for (const key of Object.keys(fields)) {
+						merged[key] = row[key]!;
+					}
+					Object.assign(merged, extra);
+					return inheritableIntoWorkable(merged) as Workable<C>;
+				};
+			}
+
 			if (typeof prop === "string" && TRAVERSAL_VERBS.has(prop)) {
 				// biome-ignore lint/suspicious/noExplicitAny: dynamic dispatch onto the row's id-record traversal verb
 				const idRecord = (target as any).id;

--- a/src/utils/workable.ts
+++ b/src/utils/workable.ts
@@ -1,5 +1,13 @@
+import { mergeSchemas } from "../query/subject.ts";
 import type { Orm } from "../schema";
-import { type AbstractType, ArrayType, GraphType } from "../types";
+import {
+	type AbstractType,
+	ArrayType,
+	GraphType,
+	type ObjectType,
+	OptionType,
+	RecordType,
+} from "../types";
 import type { DisplayContext } from "./display";
 
 export const __display: unique symbol = Symbol("display");
@@ -44,18 +52,70 @@ export function intoWorkable<C extends WorkableContext, T extends AbstractType>(
 	};
 }
 
-export function workableGet(workable: Workable, key: string | number) {
-	let [type, path] = workable[__type].get(key);
+/** Wrap `type` in `OptionType` unless it already is one (no `option<option<…>>`). */
+function optional(type: AbstractType): AbstractType {
+	return type instanceof OptionType ? type : new OptionType(type);
+}
 
-	if (workable[__type] instanceof GraphType && workable[__type].tb !== "*") {
-		const table = workable[__ctx].orm.tables[workable[__type].tb];
-		const schema = table?.schema;
-		if (schema) {
-			const [fieldType, fieldPath] = schema.get(key);
-			type = new ArrayType(fieldType);
-			path = fieldPath;
-		}
+/** The schema a record link's fields resolve against, or `undefined` if none. */
+function linkedSchema(orm: Orm, tb: RecordType["tb"]): ObjectType | undefined {
+	const names = typeof tb === "string" ? [tb] : Array.isArray(tb) ? tb : [];
+	const schemas: ObjectType[] = [];
+	for (const name of names) {
+		const schema = orm.tables[name]?.schema;
+		if (schema) schemas.push(schema as ObjectType);
 	}
+	if (schemas.length === 0) return undefined;
+	return schemas.length === 1 ? schemas[0] : mergeSchemas(schemas);
+}
+
+/**
+ * Resolve which type a property access should be looked up against, peeling the
+ * "see-through" wrappers SurrealDB dereferences transparently:
+ *
+ * - `option<T>` is transparent for access (SurrealDB returns `NONE` when reading
+ *   through a `NONE`), so we descend into `T` and re-wrap the accessed field in
+ *   `option<…>` to keep it optional.
+ * - a record link `record<tb>` resolves its fields against `tb`'s schema (a
+ *   single table, or the {@link mergeSchemas | merged} schema of a multi-table
+ *   link); the field keeps its own type — unlike a graph step, which yields an
+ *   array of links.
+ * - a graph step `->edge->tb` resolves against `tb` but wraps each field in
+ *   `array<…>`, because a step yields many records.
+ *
+ * Anything else (objects, arrays, scalars) resolves against itself. An
+ * unregistered or unknown target table falls back to the type's own `get`,
+ * which yields `NoneType` — matching the pre-existing graph behaviour.
+ */
+function resolveAccessType(
+	orm: Orm,
+	type: AbstractType,
+): { target: AbstractType; rewrap: (field: AbstractType) => AbstractType } {
+	if (type instanceof OptionType) {
+		const inner = resolveAccessType(orm, type.schema);
+		return { target: inner.target, rewrap: (f) => optional(inner.rewrap(f)) };
+	}
+
+	if (type instanceof GraphType && type.tb !== "*") {
+		const schema = orm.tables[type.tb]?.schema;
+		if (schema) return { target: schema, rewrap: (f) => new ArrayType(f) };
+	}
+
+	if (type instanceof RecordType) {
+		const schema = linkedSchema(orm, type.tb);
+		if (schema) return { target: schema, rewrap: (f) => f };
+	}
+
+	return { target: type, rewrap: (f) => f };
+}
+
+export function workableGet(workable: Workable, key: string | number) {
+	const { target, rewrap } = resolveAccessType(
+		workable[__ctx].orm,
+		workable[__type],
+	);
+	const [fieldType, path] = target.get(key);
+	const type = rewrap(fieldType);
 
 	return {
 		[__ctx]: workable[__ctx],

--- a/tests/unit/completions/fields.completions.test.ts
+++ b/tests/unit/completions/fields.completions.test.ts
@@ -5,13 +5,21 @@ const SCHEMA = `
 import { orm, t, table } from "./src";
 import { Surreal } from "surrealdb";
 
+const designer = table("designer", { displayName: t.string() });
+const product = table("product", {
+	designer: t.record("designer"),
+	createdAt: t.date(),
+});
 const user = table("user", {
 	name: t.object({ first: t.string(), last: t.string() }),
 	age: t.number(),
+	favourite: t.record("product"),
+	carts: t.array(t.object({ total: t.number(), label: t.string() })),
+	coupons: t.option(t.array(t.string())),
 });
 const post = table("post", { title: t.string() });
 
-const db = orm(new Surreal(), user, post);
+const db = orm(new Surreal(), designer, product, user, post);
 void [db];
 `;
 
@@ -63,5 +71,67 @@ describe("field-name autocomplete", () => {
 			"name",
 			"age",
 		);
+	});
+
+	// ─── #37 — record-link field access ──────────────────────────────────────
+
+	test("a record-link field exposes the linked table's fields", () => {
+		expectCompletions(`db.select("user").where((row) => row.favourite.|)`)
+			.toSuggest("designer", "createdAt")
+			.notToSuggest("name", "age");
+	});
+
+	test("chained record links expose the deeper table's fields", () => {
+		expectCompletions(
+			`db.select("user").where((row) => row.favourite.designer.|)`,
+		).toSuggest("displayName");
+	});
+
+	// ─── #36 — array element access ──────────────────────────────────────────
+
+	test("an array field offers element accessors", () => {
+		expectCompletions(
+			`db.select("user").where((row) => row.carts.|)`,
+		).toSuggest("at", "len");
+	});
+
+	test("a bracket-indexed array element exposes its object fields", () => {
+		expectCompletions(`db.select("user").where((row) => row.carts[0].|)`)
+			.toSuggest("total", "label")
+			.notToSuggest("name");
+	});
+
+	test("an .at(index) array element exposes its object fields", () => {
+		expectCompletions(
+			`db.select("user").where((row) => row.carts.at(0).|)`,
+		).toSuggest("total", "label");
+	});
+
+	// ─── #39 — row.extend({ … }) ─────────────────────────────────────────────
+
+	test("the projection row offers .extend", () => {
+		expectCompletions(`db.select("user").return((row) => row.|)`).toSuggest(
+			"extend",
+		);
+	});
+
+	test("fields stay suggestable inside an extend({ … }) computed value", () => {
+		expectCompletions(
+			`db.select("user").return((row) => row.extend({ x: row.| }))`,
+		).toSuggest("name", "age");
+	});
+
+	// ─── option<T> accessors ─────────────────────────────────────────────────
+
+	test("an option field offers unwrap / unwrapOr / isNone / isSome", () => {
+		expectCompletions(
+			`db.select("user").where((row) => row.coupons.|)`,
+		).toSuggest("unwrap", "unwrapOr", "isNone", "isSome");
+	});
+
+	test("unwrap() exposes the inner array's methods", () => {
+		expectCompletions(
+			`db.select("user").where((row) => row.coupons.unwrap().|)`,
+		).toSuggest("at", "len");
 	});
 });

--- a/tests/unit/query/nested-field-access.test.ts
+++ b/tests/unit/query/nested-field-access.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from "bun:test";
+import { RecordId, Surreal } from "surrealdb";
+import { __display, and, displayContext, orm, t, table } from "../../../src";
+
+const designer = table("designer", { name: t.string() });
+
+const product = table("product", {
+	designer: t.record("designer"),
+	created_at: t.date(),
+});
+
+const variant = table("variant", {
+	base_product: t.record("product"),
+	// a multi-table record link; both members share `firstName`
+	reviewer: t.record(["user", "admin"]),
+});
+
+const user = table("user", {
+	firstName: t.string(),
+	lastName: t.string(),
+	age: t.number(),
+});
+
+const admin = table("admin", {
+	firstName: t.string(),
+	level: t.number(),
+});
+
+const checkout = table("checkout", {
+	products: t.array(t.object({ created_at: t.date(), qty: t.number() })),
+	links: t.array(t.record("product")),
+	coupons: t.option(t.array(t.string())),
+	owner: t.option(t.record("designer")),
+	note: t.option(t.string()),
+});
+
+const db = orm(
+	new Surreal(),
+	designer,
+	product,
+	variant,
+	user,
+	admin,
+	checkout,
+);
+
+function render(query: {
+	[__display]: (ctx: ReturnType<typeof displayContext>) => string;
+}) {
+	return query[__display](displayContext());
+}
+
+// ─── #37 — nested field access through record links ─────────────────────────
+
+describe("#37 record-link field access in .where", () => {
+	test("resolves a single-table link field and renders a dotted path", () => {
+		const query = db
+			.select("variant")
+			.where((v) => v.base_product.designer.eq(new RecordId("designer", "x")));
+
+		expect(render(query)).toContain("$this.base_product.designer =");
+	});
+
+	test("chains through two links (variant → product → designer → name)", () => {
+		const query = db
+			.select("variant")
+			.where((v) => v.base_product.designer.name.eq("Ada"));
+
+		expect(render(query)).toContain("$this.base_product.designer.name =");
+	});
+
+	test("resolves a field shared across a multi-table link", () => {
+		const query = db
+			.select("variant")
+			.where((v) => v.reviewer.firstName.eq("Grace"));
+
+		expect(render(query)).toContain("$this.reviewer.firstName =");
+	});
+});
+
+// ─── #36 — array element / nested access in .where ───────────────────────────
+
+describe("#36 array element access in .where", () => {
+	test("bracket index then nested object field", () => {
+		// bracket access is `T | undefined` under noUncheckedIndexedAccess, hence `!`
+		const query = db
+			.select("checkout")
+			.where((c) => c.products[0]!.created_at.lt(new Date(0)));
+
+		expect(render(query)).toContain("$this.products[0].created_at <");
+	});
+
+	test(".at(index) then nested object field resolves against the element", () => {
+		const query = db
+			.select("checkout")
+			.where((c) => c.products.at(0).created_at.lt(new Date(0)));
+
+		const sql = render(query);
+		expect(sql).toContain("array::at($this.products,");
+		expect(sql).toContain(").created_at <");
+	});
+
+	test(".len() renders array::len", () => {
+		const query = db.select("checkout").where((c) => c.products.len().gt(2));
+
+		expect(render(query)).toContain("array::len($this.products) >");
+	});
+
+	test("array of record links: index then link field (#36 × #37)", () => {
+		const query = db
+			.select("checkout")
+			.where((c) => c.links[0]!.designer.eq(new RecordId("designer", "y")));
+
+		expect(render(query)).toContain("$this.links[0].designer =");
+	});
+
+	test("combines element conditions with and()", () => {
+		const query = db
+			.select("checkout")
+			.where((c) =>
+				and(
+					c.products[0]!.created_at.lt(new Date(0)),
+					c.products.at(0).qty.gt(1),
+				),
+			);
+
+		const sql = render(query);
+		expect(sql).toContain("$this.products[0].created_at <");
+		expect(sql).toContain(".qty >");
+	});
+});
+
+// ─── option<T> accessors: unwrap / isNone / isSome ───────────────────────────
+
+describe("option<T> methods", () => {
+	test("unwrap() exposes inner array methods (identity on the path)", () => {
+		const query = db
+			.select("checkout")
+			.where((c) => c.coupons.unwrap().at(0).eq("SAVE"));
+
+		expect(render(query)).toContain("array::at($this.coupons,");
+	});
+
+	test("unwrap() exposes inner record-link fields", () => {
+		const query = db
+			.select("checkout")
+			.where((c) => c.owner.unwrap().name.eq("Ada"));
+
+		expect(render(query)).toContain("$this.owner.name =");
+	});
+
+	test("unwrapOr(fallback) renders the ?? coalescing operator", () => {
+		const query = db
+			.select("checkout")
+			.where((c) => c.note.unwrapOr("n/a").eq("x"));
+
+		expect(render(query)).toContain("($this.note ?? ");
+	});
+
+	test("isNone() renders IS NONE", () => {
+		const query = db.select("checkout").where((c) => c.note.isNone());
+		expect(render(query)).toContain("$this.note IS NONE");
+	});
+
+	test("isSome() renders IS NOT NONE", () => {
+		const query = db.select("checkout").where((c) => c.coupons.isSome());
+		expect(render(query)).toContain("$this.coupons IS NOT NONE");
+	});
+
+	test("isSomeAnd(cb) guards presence then applies the predicate", () => {
+		const query = db
+			.select("checkout")
+			.where((c) => c.coupons.isSomeAnd((cs) => cs.len().gt(0)));
+
+		const sql = render(query);
+		expect(sql).toContain("$this.coupons IS NOT NONE AND");
+		expect(sql).toContain("array::len($this.coupons) >");
+	});
+});

--- a/tests/unit/query/return-projections.test.ts
+++ b/tests/unit/query/return-projections.test.ts
@@ -145,6 +145,45 @@ describe("SELECT return projections", () => {
 		const query = db.select("user").return((r) => r.age);
 		expect(query[__display](displayContext())).toContain("SELECT VALUE");
 	});
+
+	// ─── #39 — row.extend({ … }) ─────────────────────────────────────────────
+
+	test("extend({ … }) projects every row field plus the computed field", () => {
+		const query = db
+			.select("user")
+			.return((r) => r.extend({ fullName: r.email }));
+		const result = query[__display](displayContext());
+
+		expect(result).toContain("SELECT VALUE");
+		// every existing field is spread in…
+		expect(result).toContain("name: $this.name");
+		expect(result).toContain("age: $this.age");
+		expect(result).toContain("email: $this.email");
+		expect(result).toContain("tags: $this.tags");
+		// …plus the added field
+		expect(result).toContain("fullName: $this.email");
+	});
+
+	test("extend({ … }) lets a computed field override an existing one", () => {
+		const query = db
+			.select("user")
+			.return((r) => r.extend({ email: r.name.first }));
+		const result = query[__display](displayContext());
+
+		// the override wins; the field is not also emitted with its original value
+		expect(result).toContain("email: $this.name.first");
+		expect(result).not.toContain("email: $this.email");
+	});
+
+	test("extend({ … }) accepts a nested object as a computed field", () => {
+		const query = db
+			.select("user")
+			.return((r) => r.extend({ contact: { mail: r.email } }));
+		const result = query[__display](displayContext());
+
+		expect(result).toContain("contact: {");
+		expect(result).toContain("mail: $this.email");
+	});
 });
 
 // ─── CREATE ──────────────────────────────────────────────────────────────────

--- a/tests/unit/utils/workable.test.ts
+++ b/tests/unit/utils/workable.test.ts
@@ -103,6 +103,56 @@ describe("workableGet", () => {
 		const child = workableGet(workable, "age");
 		expect(child[__type].name).toBe("number");
 	});
+
+	test("resolves a record-link field against the linked table schema", () => {
+		const designer = table("designer", { name: t.string() });
+		const product = table("product", { designer: t.record("designer") });
+		const db = orm(new Surreal(), designer, product);
+
+		// a workable representing a `record<designer>` reference
+		const link = {
+			[__ctx]: { orm: db, id: Symbol() },
+			[__display]: () => "$this.designer",
+			[__type]: t.record("designer"),
+		};
+
+		const child = workableGet(link, "name");
+		expect(child[__type].name).toBe("string");
+		expect(child[__display](displayContext())).toBe("$this.designer.name");
+	});
+
+	test("an unregistered record-link table falls back to none", () => {
+		const db = orm(new Surreal(), table("a", { x: t.string() }));
+		const link = {
+			[__ctx]: { orm: db, id: Symbol() },
+			[__display]: () => "$this.ref",
+			[__type]: t.record("missing"),
+		};
+
+		const child = workableGet(link, "whatever");
+		expect(child[__type].name).toBe("none");
+	});
+
+	test("an option<object> field keeps the accessed field optional", () => {
+		const schema = t.object({
+			profile: t.option(t.object({ bio: t.string() })),
+		});
+		const workable = {
+			[__ctx]: { orm: {} as never, id: Symbol() },
+			[__display]: () => "$this",
+			[__type]: schema,
+		};
+
+		const profile = workableGet(workable, "profile");
+		expect(profile[__type].name).toBe("option");
+
+		// accessing through the option stays optional, without double-wrapping
+		const bio = workableGet(profile, "bio");
+		expect(bio[__type].name).toBe("option");
+		expect(
+			(bio[__type] as unknown as { schema: { name: string } }).schema.name,
+		).toBe("string");
+	});
 });
 
 describe("sanitizeWorkable", () => {


### PR DESCRIPTION
Closes #36, #37, #39.

## Problem

Field references resolve through `ObjectType` and (specially) `GraphType`, but `RecordType` (record links) and `OptionType` (optional fields) were inert — no nested access, no function resolution. This was the shared root cause behind #36 and #37.

## Changes

### Nested access through record links & options (#36, #37)
Made `RecordType` and `OptionType` "see-through" in both layers that must stay in sync:
- **Runtime:** `resolveAccessType` in `workableGet` peels `option<T>` (re-wrapping the accessed field optional), resolves `record<tb>` against the linked table schema (single, or merged via `mergeSchemas` for multi-table links), and keeps the existing graph array-wrapping.
- **Type:** matching `OptionType`/`RecordType` branches in `ActionableProps` (`RecordFields` reuses the now-exported `MergeFields`).

So `v.base_product.designer.eq(x)` (#37) and `c.products[0].created_at` / `c.products.at(0).created_at` / `c.products.len()` (#36) all resolve and type correctly, including arrays of record links (`c.links[0].designer`).

Also fixed `array::at`, which returned the whole array type instead of the element — so `.at(0).field` never resolved against the element.

### `row.extend({ ... })` (#39)
Projects every field of the row, merged with (and overridden by) the given computed fields, returning an object projection:

```ts
db.select("user").return((u) => u.extend({ fullName: u.firstName.concat(u.lastName) }))
```

Chosen over native `{ ...u }` spread: at the type level a spread drags the operator methods (`.eq`, `.len`, …) into the projection, breaking the `Inheritable` constraint; and `?.`/spread are runtime JS constructs with no query meaning.

### Explicit `option<T>` accessors
Field/index access through an option is transparent (faithful to SurrealDB's NONE-propagation), but calling a *type-specific method* on an option is blocked by the method's `this` constraint. Added explicit accessors:
- `unwrap()` — shed the wrapper to chain the inner type's fields/methods (identity on the rendered path)
- `unwrapOr(default)` — `(x ?? default)` coalescing, yields non-optional inner
- `isNone()` / `isSome()` — `IS NONE` / `IS NOT NONE`
- `isSomeAnd(cb)` — `(x IS NOT NONE AND <pred>)`

Also fixed a latent `this`-rebinding infinite recursion in `option.map()`'s display (a method-shorthand `[__display](ctx){}` recursing on `this[__display]`; now an arrow).

## Tests
- `tests/unit/query/nested-field-access.test.ts` — new, covers #36/#37 + option accessors
- `tests/unit/query/return-projections.test.ts` — `extend()` cases
- `tests/unit/utils/workable.test.ts` — record/option resolution
- `tests/unit/completions/fields.completions.test.ts` — autocomplete for link/array/element/`extend`/option methods

All green: 648 unit tests, `tsc --noEmit`, and `biome check` pass. (Integration tests need a live SurrealDB and were not run.)