### PR TITLE
Add fluent array.map() support for array::map

### DIFF
--- a/README.md
+++ b/README.md
@@ -968,6 +968,7 @@ db.select("post").return((post) => ({
   unique: post.tags.distinct(),    // Unique values
   flat: post.tags.flatten(),       // Flatten nested arrays
   reversed: post.tags.reverse(),   // Reverse array
+  map: post.tags.map((tag, index) => tag.uppercase()) // Map array
 }));
 ```
 

--- a/src/functions/types/array.ts
+++ b/src/functions/types/array.ts
@@ -11,13 +11,19 @@ import {
 } from "../../types";
 import {
 	__ctx,
+	__display,
 	__type,
 	type IntoWorkable,
 	intoWorkable,
 	type Workable,
 	type WorkableContext,
 } from "../../utils";
-import type { Actionable } from "../../utils/actionable";
+import { type Actionable, actionable } from "../../utils/actionable";
+import {
+	type Inheritable,
+	type InheritableIntoType,
+	inheritableIntoWorkable,
+} from "../../utils/inheritable";
 import type { At } from "../../utils/types";
 import { comparingFilter } from "../filters";
 import { databaseFunction } from "../utils";
@@ -526,6 +532,8 @@ export const functions = {
 		);
 	},
 
+	map,
+
 	at,
 
 	val,
@@ -784,6 +792,26 @@ export type Functions = {
 		size: IntoWorkable<C, NumberType>,
 	): Actionable<C, ArrayType<T>>;
 
+	map<
+		C extends WorkableContext,
+		T extends AbstractType[],
+		R extends Inheritable<C>,
+	>(
+		this: Workable<C, ArrayType<T>>,
+		cb: (
+			item: Actionable<C, UnionType<T>>,
+			index: Actionable<C, NumberType>,
+		) => R,
+	): Actionable<C, ArrayType<InheritableIntoType<C, R>>>;
+	map<
+		C extends WorkableContext,
+		T extends AbstractType,
+		R extends Inheritable<C>,
+	>(
+		this: Workable<C, ArrayType<T>>,
+		cb: (item: Actionable<C, T>, index: Actionable<C, NumberType>) => R,
+	): Actionable<C, ArrayType<InheritableIntoType<C, R>>>;
+
 	at<C extends WorkableContext, T extends AbstractType[], N extends number>(
 		this: Workable<C, ArrayType<T>>,
 		n: IntoWorkable<C, LiteralType<N>>,
@@ -814,6 +842,59 @@ export type Functions = {
 };
 
 // Array functions which require overloading signatures
+
+type ArrayMapElement<T extends AbstractType[] | AbstractType> =
+	T extends AbstractType[] ? UnionType<T> : T extends AbstractType ? T : never;
+
+function map<
+	C extends WorkableContext,
+	T extends AbstractType[],
+	R extends Inheritable<C>,
+>(
+	this: Workable<C, ArrayType<T>>,
+	cb: (
+		item: Actionable<C, UnionType<T>>,
+		index: Actionable<C, NumberType>,
+	) => R,
+): Actionable<C, ArrayType<InheritableIntoType<C, R>>>;
+function map<
+	C extends WorkableContext,
+	T extends AbstractType,
+	R extends Inheritable<C>,
+>(
+	this: Workable<C, ArrayType<T>>,
+	cb: (item: Actionable<C, T>, index: Actionable<C, NumberType>) => R,
+): Actionable<C, ArrayType<InheritableIntoType<C, R>>>;
+function map<
+	C extends WorkableContext,
+	T extends AbstractType[] | AbstractType,
+	R extends Inheritable<C>,
+>(
+	this: Workable<C, ArrayType<T>>,
+	cb: (
+		item: Actionable<C, ArrayMapElement<T>>,
+		index: Actionable<C, NumberType>,
+	) => R,
+) {
+	const item = actionable({
+		[__ctx]: this[__ctx],
+		[__type]: elementType(this[__type]),
+		[__display]: () => "$item",
+	}) as Actionable<C, ArrayMapElement<T>>;
+	const index = actionable({
+		[__ctx]: this[__ctx],
+		[__type]: t.number(),
+		[__display]: () => "$index",
+	});
+	const result = inheritableIntoWorkable(cb(item, index));
+
+	return actionable({
+		[__ctx]: this[__ctx],
+		[__type]: t.array(result[__type]),
+		[__display]: (ctx) =>
+			`array::map(${this[__display](ctx)}, |$item, $index| ${result[__display](ctx)})`,
+	});
+}
 
 function at<
 	C extends WorkableContext,

--- a/src/schema/lookup.ts
+++ b/src/schema/lookup.ts
@@ -126,7 +126,7 @@ type LookupState = {
 };
 
 const asArray = (x: string | readonly string[]): readonly string[] =>
-	Array.isArray(x) ? x : [x];
+	typeof x === "string" ? [x] : x;
 
 function ensureNode(lookup: LookupState, node: string): void {
 	if (!lookup.to[node]) lookup.to[node] = [];

--- a/src/schema/lookup.ts
+++ b/src/schema/lookup.ts
@@ -126,7 +126,7 @@ type LookupState = {
 };
 
 const asArray = (x: string | readonly string[]): readonly string[] =>
-	typeof x === "string" ? [x] : x;
+	Array.isArray(x) ? x : [x];
 
 function ensureNode(lookup: LookupState, node: string): void {
 	if (!lookup.to[node]) lookup.to[node] = [];

--- a/tests/unit/functions/array.test.ts
+++ b/tests/unit/functions/array.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+import { Surreal } from "surrealdb";
+import { __display, displayContext, orm, t, table } from "../../../src";
+
+describe("Array functions", () => {
+	const user = table("user", {
+		name: t.string(),
+		tags: t.array(t.string()),
+		scores: t.array(t.number()),
+	});
+
+	const db = orm(new Surreal(), user);
+
+	test("map() generates array::map", () => {
+		const query = db.select("user").return((user) => ({
+			mapped: user.tags.map((tag) => tag.uppercase()),
+		}));
+		const ctx = displayContext();
+		const result = query[__display](ctx);
+
+		expect(result).toContain("array::map");
+		expect(result).toContain("string::uppercase");
+		expect(result).toContain("$this.tags");
+		expect(result).toContain("|$item, $index|");
+		expect(result).toContain("$item");
+	});
+
+	test("map() callback item can use string methods", () => {
+		const query = db.select("user").return((user) => ({
+			lengths: user.tags.map((tag) => tag.len()),
+		}));
+		const ctx = displayContext();
+		const result = query[__display](ctx);
+
+		expect(result).toContain("array::map");
+		expect(result).toContain("string::len");
+		expect(result).toContain("$item");
+		expect(result).toContain("|$item, $index|");
+	});
+
+	test("map() exposes the index parameter", () => {
+		const query = db.select("user").return((user) => ({
+			indexes: user.tags.map((_tag, index) => index),
+		}));
+		const ctx = displayContext();
+		const result = query[__display](ctx);
+
+		expect(result).toContain("array::map");
+		expect(result).toContain("$index");
+		expect(result).toContain("|$item, $index|");
+	});
+
+	test("map() supports object literal callback returns", () => {
+		const query = db.select("user").return((user) => ({
+			tagDetails: user.tags.map((tag, index) => ({
+				index,
+				upper: tag.uppercase(),
+				length: tag.len(),
+			})),
+		}));
+		const ctx = displayContext();
+		const result = query[__display](ctx);
+
+		expect(result).toContain("array::map");
+		expect(result).toContain("tagDetails:");
+		expect(result).toContain("index: $index");
+		expect(result).toContain("upper:");
+		expect(result).toContain("length:");
+		expect(result).toContain("string::uppercase");
+		expect(result).toContain("string::len");
+	});
+
+	test("map() works inside a return projection", () => {
+		const query = db.select("user").return((user) => ({
+			mapped: user.tags.map((tag) => tag.uppercase()),
+		}));
+		const ctx = displayContext();
+		const result = query[__display](ctx);
+
+		expect(result).toContain("SELECT VALUE");
+		expect(result).toContain("mapped:");
+		expect(result).toContain("array::map");
+	});
+
+	test("map() supports numeric array mapping", () => {
+		const query = db.select("user").return((user) => ({
+			rounded: user.scores.map((score) => score.round()),
+		}));
+		const ctx = displayContext();
+		const result = query[__display](ctx);
+
+		expect(result).toContain("array::map");
+		expect(result).toContain("math::round");
+		expect(result).toContain("$this.scores");
+		expect(result).toContain("$item");
+	});
+});


### PR DESCRIPTION
This PR adds fluent `.map()` support for SurQLize array fields, wrapping SurrealDB’s `array::map(array, closure)` function.

It allows array fields to be mapped directly from the query builder:

```js
const query = db.select("user").return((user) => ({
  upperTags: user.tags.map((tag) => tag.uppercase()),
}));

```
The callback also receives the item index:

```js
const query = db.select("user").return((user) => ({
  tagDetails: user.tags.map((tag, index) => ({
    index,
    upper: tag.uppercase(),
    length: tag.len(),
  })),
}));
```

## Optional array note

For fields typed as `t.option(t.array(...))`, calling `.map()` directly uses `option.map()`, not `array.map()`.

So optional arrays should be mapped like this:

`user.images.unwrapOr([]).map((image) => image)`
