### PR TITLE
Add .only() support for SurrealQL ONLY queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,14 +261,60 @@ const specificUser = await db.select(new RecordId("user", "john")).then.val();
 // Or get a specific item:
 const specificUser = await db.select(new RecordId("user", "john")).then.at(0);
 
+// Use .only() to emit SurrealQL ONLY and return a single object instead of an array
+const user = await db.select("user", "john").only();
+// user: User  (not User[])
+
 // Nested queries (JOIN-like)
 const postsWithAuthors = db.select("post").return((post) => ({
   title: post.title,
-  author: post.authorId.select().return((author) => ({
+  author: post.authorId.select().only().return((author) => ({
     name: author.name,
     email: author.email,
   })),
 }));
+
+// Without .only(), post.authorId.select() returns an array per post.
+// With .only(), each post returns a single author object.
+```
+
+#### Using `.only()` for single-record queries
+
+By default surqlize queries always return arrays. The `.only()` modifier emits the SurrealQL `ONLY` clause and changes both the generated query and the TypeScript return type to a single object:
+
+```typescript
+// Without .only() — returns User[] (array with 0 or 1 item)
+const users = await db.select("user", "john");
+
+// With .only() — emits "SELECT * FROM ONLY user:john" and returns User
+const user = await db.select("user", "john").only();
+```
+
+This is different from `.then.val()` which extracts the first element client-side from an array result. `.only()` changes the query sent to SurrealDB.
+
+#### Nested record selects with `.only()`
+
+When selecting through a record link, omitting `.only()` returns an array per parent record. Use `.only()` when each parent has exactly one related record:
+
+```typescript
+// Without .only(): post.author.select() returns User[] per post → nested arrays
+const posts = await db.select("post").return((post) => ({
+  title: post.title,
+  author: post.author.select().return((author) => ({
+    id: author.id,
+    username: author.username,
+  })),
+}));
+
+// With .only(): each post returns a single author object
+const posts = await db.select("post").return((post) => ({
+  title: post.title,
+  author: post.author.select().only().return((author) => ({
+    id: author.id,
+    username: author.username,
+  })),
+}));
+// Result: Array<{ title: string; author: { id: RecordId<"user">; username: string } }>
 ```
 
 #### Sorting with ORDER BY
@@ -416,6 +462,13 @@ const user = await db.create("user", "alice123").set({
 const created = await db.create("user")
   .set({ name: "Bob" })
   .return("after"); // or "before", "none", "diff"
+
+// Use .only() to return a single object instead of an array
+const user = await db
+  .create("user", "john")
+  .only()
+  .set({ name: "John" });
+// user: User  (not User[])
 ```
 
 ### INSERT statements
@@ -502,6 +555,13 @@ await db.upsert("user", "alice")
 await db.upsert("user")
   .where((u) => u.email.eq("alice@example.com"))
   .set({ lastSeen: new Date() });
+
+// Use .only() to return a single object instead of an array
+const upserted = await db
+  .upsert("user", "john")
+  .only()
+  .set({ name: "John" });
+// upserted: User  (not User[])
 ```
 
 ### UPDATE statements
@@ -555,6 +615,13 @@ const updated = await db.update("user")
   .where((u) => u.age.gt(65))
   .set({ status: "senior" })
   .return("after");
+
+// Use .only() to return a single object instead of an array
+const user = await db
+  .update("user", "john")
+  .only()
+  .set({ name: "Johnny" });
+// user: User  (not User[])
 ```
 
 ### RELATE statements
@@ -624,6 +691,12 @@ const edgeInfo = await db.relate(
 const userQuery = db.select("user", "alice");
 const postQuery = db.select("post", "hello");
 await db.relate("authored", userQuery, postQuery);
+
+// Use .only() to return a single edge object instead of an array
+const relation = await db
+  .relate("authored", new RecordId("user", "alice"), new RecordId("post", "hello-world"))
+  .only();
+// relation: Authored  (not Authored[])
 ```
 
 ### DELETE statements
@@ -645,6 +718,14 @@ const deleted = await db.delete("user")
 const deletedNames = await db.delete("user")
   .where((u) => u.email.endsWith("@spam.com"))
   .return((u) => ({ name: u.name }));
+
+// Use .only() to return a single object instead of an array.
+// DELETE ONLY is most useful with RETURN BEFORE when the deleted record should be returned.
+const deleted = await db
+  .delete("user", "alice")
+  .only()
+  .return("before");
+// deleted: User  (not User[])
 ```
 
 ## Batch

--- a/src/query/abstract.ts
+++ b/src/query/abstract.ts
@@ -1,5 +1,5 @@
 import { BoundQuery } from "surrealdb";
-import type { AbstractType } from "../types";
+import type { AbstractType, ArrayType } from "../types";
 import {
 	__ctx,
 	__display,
@@ -10,6 +10,11 @@ import {
 	type WorkableContext,
 } from "../utils";
 import { type Actionable, actionable } from "../utils/actionable";
+
+export type QueryResult<
+	E extends AbstractType,
+	Only extends boolean,
+> = Only extends true ? E : ArrayType<E>;
 
 /**
  * Abstract base class for all query types. Implements `Workable` so queries can

--- a/src/query/create.ts
+++ b/src/query/create.ts
@@ -1,11 +1,6 @@
 import { RecordId, type RecordIdValue, Table } from "surrealdb";
 import type { Orm } from "../schema/orm.ts";
-import {
-	type AbstractType,
-	type ArrayType,
-	type ObjectType,
-	t,
-} from "../types";
+import { type AbstractType, type ObjectType, t } from "../types";
 import { type Actionable, actionable } from "../utils/actionable.ts";
 import { type DisplayContext, displayContext } from "../utils/display.ts";
 import {
@@ -21,7 +16,7 @@ import {
 	type Workable,
 	type WorkableContext,
 } from "../utils/workable.ts";
-import { Query } from "./abstract.ts";
+import { Query, type QueryResult } from "./abstract.ts";
 import {
 	applyContent,
 	applyMerge,
@@ -44,11 +39,13 @@ export class CreateQuery<
 		C extends WorkableContext<O>,
 		T extends keyof O["tables"] & string,
 		E extends AbstractType = O["tables"][T]["schema"],
+		Only extends boolean = false,
 	>
-	extends Query<C, ArrayType<E>>
+	extends Query<C, QueryResult<E, Only>>
 	implements ModificationState
 {
 	readonly [__ctx]: C;
+	private _only = false;
 	_set?: Record<string, unknown>;
 	_content?: unknown;
 	_merge?: unknown;
@@ -76,11 +73,18 @@ export class CreateQuery<
 		return this[__ctx].orm.tables[this.tb]!.schema as unknown as E;
 	}
 
-	get [__type](): ArrayType<E> {
-		if (this._return && typeof this._return !== "string") {
-			return t.array(this._return[__type]) as ArrayType<E>;
-		}
-		return t.array(this.schema);
+	get [__type](): QueryResult<E, Only> {
+		const schema =
+			this._return && typeof this._return !== "string"
+				? this._return[__type]
+				: this.schema;
+		return (this._only ? schema : t.array(schema)) as QueryResult<E, Only>;
+	}
+
+	only(): CreateQuery<O, C, T, E, true> {
+		return this.derive((next) => {
+			next._only = true;
+		}) as CreateQuery<O, C, T, E, true>;
 	}
 
 	set(data: E extends ObjectType ? Partial<SetData<E>> : never): this {
@@ -110,7 +114,7 @@ export class CreateQuery<
 	return(mode: "none" | "before" | "after" | "diff"): this;
 	return(
 		cb: (record: Actionable<C, E>) => Inheritable<C>,
-	): CreateQuery<O, C, T, InheritableIntoType<C, ReturnType<typeof cb>>>;
+	): CreateQuery<O, C, T, InheritableIntoType<C, ReturnType<typeof cb>>, Only>;
 	return(
 		value:
 			| "none"
@@ -163,7 +167,7 @@ export class CreateQuery<
 			target = ctx.var(new Table(this.tb));
 		}
 
-		let query = /* surql */ `CREATE ${target}`;
+		let query = /* surql */ `CREATE ${this._only ? "ONLY " : ""}${target}`;
 
 		query += displayModificationClause(this, ctx);
 

--- a/src/query/delete.ts
+++ b/src/query/delete.ts
@@ -1,11 +1,6 @@
 import { type RecordId, Table } from "surrealdb";
 import type { Orm } from "../schema/orm.ts";
-import {
-	type AbstractType,
-	type ArrayType,
-	type RecordType,
-	t,
-} from "../types";
+import { type AbstractType, type RecordType, t } from "../types";
 import { type Actionable, actionable } from "../utils/actionable.ts";
 import { type DisplayContext, displayContext } from "../utils/display.ts";
 import {
@@ -22,7 +17,7 @@ import {
 	type Workable,
 	type WorkableContext,
 } from "../utils/workable.ts";
-import { Query } from "./abstract.ts";
+import { Query, type QueryResult } from "./abstract.ts";
 import { resolveSubjectSchema } from "./subject.ts";
 
 /**
@@ -33,8 +28,10 @@ export class DeleteQuery<
 	C extends WorkableContext<O>,
 	T extends keyof O["tables"] & string,
 	E extends AbstractType = O["tables"][T]["schema"],
-> extends Query<C, ArrayType<E>> {
+	Only extends boolean = false,
+> extends Query<C, QueryResult<E, Only>> {
 	readonly [__ctx]: C;
+	private _only = false;
 	private _filter?: Workable<C>;
 	private _return?: "none" | "before" | "after" | "diff" | Workable<C, E>;
 	private _timeout?: string;
@@ -64,11 +61,18 @@ export class DeleteQuery<
 		return resolveSubjectSchema(this[__ctx].orm, this.tb) as unknown as E;
 	}
 
-	get [__type](): ArrayType<E> {
-		if (this._return && typeof this._return !== "string") {
-			return t.array(this._return[__type]) as ArrayType<E>;
-		}
-		return t.array(this.schema);
+	get [__type](): QueryResult<E, Only> {
+		const schema =
+			this._return && typeof this._return !== "string"
+				? this._return[__type]
+				: this.schema;
+		return (this._only ? schema : t.array(schema)) as QueryResult<E, Only>;
+	}
+
+	only(): DeleteQuery<O, C, T, E, true> {
+		return this.derive((next) => {
+			next._only = true;
+		}) as DeleteQuery<O, C, T, E, true>;
 	}
 
 	where(cb: (tb: Actionable<C, O["tables"][T]["schema"]>) => Workable<C>) {
@@ -90,7 +94,7 @@ export class DeleteQuery<
 	return<
 		P extends Inheritable<C>,
 		R extends InheritableIntoType<C, P> = InheritableIntoType<C, P>,
-	>(cb: (tb: Actionable<C, E>) => P): DeleteQuery<O, C, T, R>;
+	>(cb: (tb: Actionable<C, E>) => P): DeleteQuery<O, C, T, R, Only>;
 	return(
 		value:
 			| "none"
@@ -143,7 +147,7 @@ export class DeleteQuery<
 					? this.subject[__display](ctx)
 					: ctx.var(this.subject);
 
-		let query = /* surql */ `DELETE ${thing}`;
+		let query = /* surql */ `DELETE ${this._only ? "ONLY " : ""}${thing}`;
 
 		if (this._filter)
 			query += /* surql */ ` WHERE ${this._filter[__display](ctx)}`;

--- a/src/query/relate.ts
+++ b/src/query/relate.ts
@@ -23,7 +23,7 @@ import {
 	type Workable,
 	type WorkableContext,
 } from "../utils/workable.ts";
-import { Query } from "./abstract.ts";
+import { Query, type QueryResult } from "./abstract.ts";
 import {
 	applyContent,
 	applyMerge,
@@ -46,11 +46,13 @@ export class RelateQuery<
 		C extends WorkableContext<O>,
 		Edge extends keyof O["tables"] & string,
 		E extends AbstractType = O["tables"][Edge]["schema"],
+		Only extends boolean = false,
 	>
-	extends Query<C, ArrayType<E>>
+	extends Query<C, QueryResult<E, Only>>
 	implements ModificationState
 {
 	readonly [__ctx]: C;
+	private _only = false;
 	_set?: Record<string, unknown>;
 	_content?: unknown;
 	_merge?: unknown;
@@ -85,11 +87,18 @@ export class RelateQuery<
 		return this[__ctx].orm.tables[this.edge]!.schema as unknown as E;
 	}
 
-	get [__type](): ArrayType<E> {
-		if (this._return && typeof this._return !== "string") {
-			return t.array(this._return[__type]) as ArrayType<E>;
-		}
-		return t.array(this.schema);
+	get [__type](): QueryResult<E, Only> {
+		const schema =
+			this._return && typeof this._return !== "string"
+				? this._return[__type]
+				: this.schema;
+		return (this._only ? schema : t.array(schema)) as QueryResult<E, Only>;
+	}
+
+	only(): RelateQuery<O, C, Edge, E, true> {
+		return this.derive((next) => {
+			next._only = true;
+		}) as RelateQuery<O, C, Edge, E, true>;
 	}
 
 	set(data: E extends ObjectType ? Partial<SetData<E>> : never): this {
@@ -121,7 +130,13 @@ export class RelateQuery<
 	return(mode: "none" | "before" | "after" | "diff"): this;
 	return(
 		cb: (record: Actionable<C, E>) => Inheritable<C>,
-	): RelateQuery<O, C, Edge, InheritableIntoType<C, ReturnType<typeof cb>>>;
+	): RelateQuery<
+		O,
+		C,
+		Edge,
+		InheritableIntoType<C, ReturnType<typeof cb>>,
+		Only
+	>;
 	return(
 		value:
 			| "none"
@@ -189,7 +204,7 @@ export class RelateQuery<
 			toStr = ctx.var(this.to);
 		}
 
-		let query = /* surql */ `RELATE ${fromStr}->${edgeTable}->${toStr}`;
+		let query = /* surql */ `RELATE ${this._only ? "ONLY " : ""}${fromStr}->${edgeTable}->${toStr}`;
 
 		query += displayModificationClause(this, ctx);
 

--- a/src/query/select.ts
+++ b/src/query/select.ts
@@ -29,7 +29,7 @@ import {
 	type Workable,
 	type WorkableContext,
 } from "../utils/workable.ts";
-import { Query } from "./abstract.ts";
+import { Query, type QueryResult } from "./abstract.ts";
 import { type ResolveEntry, resolveSubjectSchema } from "./subject.ts";
 import { escapeIdiomPath } from "./utils.ts";
 
@@ -151,8 +151,10 @@ export class SelectQuery<
 	C extends WorkableContext<O>,
 	T extends keyof O["tables"] & string,
 	E extends AbstractType = O["tables"][T]["schema"],
-> extends Query<C, ArrayType<E>> {
+	Only extends boolean = false,
+> extends Query<C, QueryResult<E, Only>> {
 	readonly [__ctx]: C;
+	private _only = false;
 	private _start?: number;
 	private _limit?: number;
 	private _filter?: Workable<C>;
@@ -218,8 +220,17 @@ export class SelectQuery<
 			resolveSubjectSchema(this[__ctx].orm, this.tb)) as E;
 	}
 
-	get [__type](): ArrayType<E> {
-		return t.array(this.entry);
+	get [__type](): QueryResult<E, Only> {
+		return (this._only ? this.entry : t.array(this.entry)) as QueryResult<
+			E,
+			Only
+		>;
+	}
+
+	only(): SelectQuery<O, C, T, E, true> {
+		return this.derive((next) => {
+			next._only = true;
+		}) as SelectQuery<O, C, T, E, true>;
 	}
 
 	/**
@@ -250,7 +261,7 @@ export class SelectQuery<
 				RowTraversal<C, T> &
 				RowExtend<C, ResolveEntry<E>>,
 		) => P,
-	): SelectQuery<O, C, T, R> {
+	): SelectQuery<O, C, T, R, Only> {
 		const tb = this.rowActionable(this.entry) as Actionable<
 			C,
 			ResolveEntry<E>
@@ -265,8 +276,8 @@ export class SelectQuery<
 		const entry = sanitizeWorkable(workable);
 
 		return this.derive((next) => {
-			(next as unknown as SelectQuery<O, C, T, R>)._entry = entry;
-		}) as unknown as SelectQuery<O, C, T, R>;
+			(next as unknown as SelectQuery<O, C, T, R, Only>)._entry = entry;
+		}) as unknown as SelectQuery<O, C, T, R, Only>;
 	}
 
 	where(
@@ -381,7 +392,7 @@ export class SelectQuery<
 
 	fetch<P extends FetchPaths<O, T>>(
 		...fields: P[]
-	): SelectQuery<O, C, T, FetchedSchema<O, E, P>> {
+	): SelectQuery<O, C, T, FetchedSchema<O, E, P>, Only> {
 		// Build a resolved schema where fetched record references are replaced
 		// with the referenced table's ObjectType schema, recursing into nested
 		// paths so parse() validates the resolved objects instead of expecting
@@ -397,7 +408,7 @@ export class SelectQuery<
 		return this.derive((next) => {
 			next._fetch = fields;
 			if (resolved) next._fetchResolvedType = resolved;
-		}) as unknown as SelectQuery<O, C, T, FetchedSchema<O, E, P>>;
+		}) as unknown as SelectQuery<O, C, T, FetchedSchema<O, E, P>, Only>;
 	}
 
 	timeout(duration: string): this {
@@ -447,7 +458,7 @@ export class SelectQuery<
 		const predicates = this._entry
 			? /* surql */ `VALUE ${this._entry[__display](ctx)}`
 			: "*";
-		let query = /* surql */ `SELECT ${predicates} FROM ${thing}`;
+		let query = /* surql */ `SELECT ${predicates} FROM ${this._only ? "ONLY " : ""}${thing}`;
 
 		if (this._filter)
 			query += /* surql */ ` WHERE ${this._filter[__display](ctx)}`;

--- a/src/query/update.ts
+++ b/src/query/update.ts
@@ -2,7 +2,6 @@ import { type RecordId, Table } from "surrealdb";
 import type { Orm } from "../schema/orm.ts";
 import {
 	type AbstractType,
-	type ArrayType,
 	type ObjectType,
 	type RecordType,
 	t,
@@ -23,7 +22,7 @@ import {
 	type Workable,
 	type WorkableContext,
 } from "../utils/workable.ts";
-import { Query } from "./abstract.ts";
+import { Query, type QueryResult } from "./abstract.ts";
 import {
 	applyContent,
 	applyMerge,
@@ -48,11 +47,13 @@ export class UpdateQuery<
 		C extends WorkableContext<O>,
 		T extends keyof O["tables"] & string,
 		E extends AbstractType = O["tables"][T]["schema"],
+		Only extends boolean = false,
 	>
-	extends Query<C, ArrayType<E>>
+	extends Query<C, QueryResult<E, Only>>
 	implements ModificationState
 {
 	readonly [__ctx]: C;
+	private _only = false;
 	_set?: Record<string, unknown>;
 	_unset?: string[];
 	_content?: unknown;
@@ -89,11 +90,18 @@ export class UpdateQuery<
 		return resolveSubjectSchema(this[__ctx].orm, this.tb) as unknown as E;
 	}
 
-	get [__type](): ArrayType<E> {
-		if (this._return && typeof this._return !== "string") {
-			return t.array(this._return[__type]) as ArrayType<E>;
-		}
-		return t.array(this.schema);
+	get [__type](): QueryResult<E, Only> {
+		const schema =
+			this._return && typeof this._return !== "string"
+				? this._return[__type]
+				: this.schema;
+		return (this._only ? schema : t.array(schema)) as QueryResult<E, Only>;
+	}
+
+	only(): UpdateQuery<O, C, T, E, true> {
+		return this.derive((next) => {
+			next._only = true;
+		}) as UpdateQuery<O, C, T, E, true>;
 	}
 
 	set(data: E extends ObjectType ? Partial<SetData<E>> : never): this {
@@ -141,7 +149,7 @@ export class UpdateQuery<
 	return<
 		P extends Inheritable<C>,
 		R extends InheritableIntoType<C, P> = InheritableIntoType<C, P>,
-	>(cb: (tb: Actionable<C, E>) => P): UpdateQuery<O, C, T, R>;
+	>(cb: (tb: Actionable<C, E>) => P): UpdateQuery<O, C, T, R, Only>;
 	return(
 		value:
 			| "none"
@@ -194,7 +202,7 @@ export class UpdateQuery<
 					? this.subject[__display](ctx)
 					: ctx.var(this.subject);
 
-		let query = /* surql */ `UPDATE ${thing}`;
+		let query = /* surql */ `UPDATE ${this._only ? "ONLY " : ""}${thing}`;
 
 		query += displayModificationClause(this, ctx);
 

--- a/src/query/upsert.ts
+++ b/src/query/upsert.ts
@@ -2,7 +2,6 @@ import { type RecordId, Table } from "surrealdb";
 import type { Orm } from "../schema/orm.ts";
 import {
 	type AbstractType,
-	type ArrayType,
 	type ObjectType,
 	type RecordType,
 	t,
@@ -23,7 +22,7 @@ import {
 	type Workable,
 	type WorkableContext,
 } from "../utils/workable.ts";
-import { Query } from "./abstract.ts";
+import { Query, type QueryResult } from "./abstract.ts";
 import {
 	applyContent,
 	applyMerge,
@@ -48,11 +47,13 @@ export class UpsertQuery<
 		C extends WorkableContext<O>,
 		T extends keyof O["tables"] & string,
 		E extends AbstractType = O["tables"][T]["schema"],
+		Only extends boolean = false,
 	>
-	extends Query<C, ArrayType<E>>
+	extends Query<C, QueryResult<E, Only>>
 	implements ModificationState
 {
 	readonly [__ctx]: C;
+	private _only = false;
 	_set?: Record<string, unknown>;
 	_content?: unknown;
 	_merge?: unknown;
@@ -88,11 +89,18 @@ export class UpsertQuery<
 		return resolveSubjectSchema(this[__ctx].orm, this.tb) as unknown as E;
 	}
 
-	get [__type](): ArrayType<E> {
-		if (this._return && typeof this._return !== "string") {
-			return t.array(this._return[__type]) as ArrayType<E>;
-		}
-		return t.array(this.schema);
+	get [__type](): QueryResult<E, Only> {
+		const schema =
+			this._return && typeof this._return !== "string"
+				? this._return[__type]
+				: this.schema;
+		return (this._only ? schema : t.array(schema)) as QueryResult<E, Only>;
+	}
+
+	only(): UpsertQuery<O, C, T, E, true> {
+		return this.derive((next) => {
+			next._only = true;
+		}) as UpsertQuery<O, C, T, E, true>;
 	}
 
 	set(data: E extends ObjectType ? Partial<SetData<E>> : never): this {
@@ -136,7 +144,7 @@ export class UpsertQuery<
 	return<
 		P extends Inheritable<C>,
 		R extends InheritableIntoType<C, P> = InheritableIntoType<C, P>,
-	>(cb: (tb: Actionable<C, E>) => P): UpsertQuery<O, C, T, R>;
+	>(cb: (tb: Actionable<C, E>) => P): UpsertQuery<O, C, T, R, Only>;
 	return(
 		value:
 			| "none"
@@ -189,7 +197,7 @@ export class UpsertQuery<
 					? this.subject[__display](ctx)
 					: ctx.var(this.subject);
 
-		let query = /* surql */ `UPSERT ${thing}`;
+		let query = /* surql */ `UPSERT ${this._only ? "ONLY " : ""}${thing}`;
 
 		query += displayModificationClause(this, ctx);
 

--- a/src/utils/workable.ts
+++ b/src/utils/workable.ts
@@ -131,9 +131,10 @@ export function sanitizeWorkable<
 	C extends WorkableContext,
 	T extends AbstractType,
 >(workable: Workable<C, T>): Workable<C, T> {
+	const display = workable[__display].bind(workable);
 	return {
 		[__ctx]: workable[__ctx],
-		[__display]: workable[__display],
+		[__display]: display,
 		[__type]: workable[__type],
 	};
 }

--- a/tests/unit/query/only.test.ts
+++ b/tests/unit/query/only.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, test } from "bun:test";
+import { RecordId, Surreal } from "surrealdb";
+import { __type, edge, orm, t, table } from "../../../src";
+
+// Compile-time equality assertion helper.
+type Equal<A, B> =
+	(<G>() => G extends A ? 1 : 2) extends <G>() => G extends B ? 1 : 2
+		? true
+		: false;
+
+const user = table("user", {
+	name: t.string(),
+	age: t.number(),
+});
+
+const post = table("post", {
+	title: t.string(),
+	author: t.record("user"),
+});
+
+const authored = edge("user", "authored", "post", {
+	created: t.date(),
+});
+
+const db = orm(new Surreal(), user, post, authored);
+type User = {
+	id: RecordId<"user">;
+	name: string;
+	age: number;
+};
+
+describe("ONLY queries", () => {
+	const aliceId = new RecordId("user", "alice");
+	const postId = new RecordId("post", "post1");
+	const alice: User = { id: aliceId, name: "Alice", age: 30 };
+
+	const render = (query: { toString(): string }) => query.toString();
+
+	test("renders ONLY for every supported builder", () => {
+		const select = render(db.select("user", "alice").only());
+		const create = render(db.create("user", "alice").only());
+		const update = render(db.update("user", "alice").only());
+		const upsert = render(db.upsert("user", "alice").only());
+		const deleteQuery = render(
+			db.delete("user", "alice").only().return("before"),
+		);
+		const relate = render(db.relate("authored", aliceId, postId).only());
+
+		expect(select).toContain("FROM ONLY");
+		expect(create).toContain("CREATE ONLY");
+		expect(update).toContain("UPDATE ONLY");
+		expect(upsert).toContain("UPSERT ONLY");
+		expect(deleteQuery).toContain("DELETE ONLY");
+		expect(deleteQuery).toContain("RETURN BEFORE");
+		expect(relate).toContain("RELATE ONLY");
+	});
+
+	test("renders ONLY inside nested SELECT VALUE projections", () => {
+		const query = db
+			.select("post")
+			.return((post) => post.author.select().only());
+		const sql = render(query);
+
+		expect(sql).toContain("SELECT VALUE");
+		expect(sql).toContain("FROM ONLY");
+	});
+
+	test("SELECT keeps array results by default and only() returns one record", () => {
+		const defaultSelect = db.select("user", "alice");
+		const onlySelect = db.select("user", "alice").only();
+
+		type DefaultResult = t.infer<typeof defaultSelect>;
+		type OnlyResult = t.infer<typeof onlySelect>;
+
+		const defaultCheck: Equal<DefaultResult, User[]> = true;
+		const onlyCheck: Equal<OnlyResult, User> = true;
+
+		expect(defaultCheck).toBe(true);
+		expect(onlyCheck).toBe(true);
+		expect(defaultSelect[__type].validate([alice])).toBe(true);
+		expect(defaultSelect[__type].validate(alice)).toBe(false);
+		expect(onlySelect[__type].validate(alice)).toBe(true);
+		expect(onlySelect[__type].validate([alice])).toBe(false);
+		expect(render(defaultSelect)).not.toContain("FROM ONLY");
+	});
+
+	test("mutation only() results are object-shaped", () => {
+		const created = db.create("user", "alice").only();
+		const updated = db.update("user", "alice").only();
+		const upserted = db.upsert("user", "alice").only();
+		const deleted = db.delete("user", "alice").only().return("before");
+
+		type Created = t.infer<typeof created>;
+		type Updated = t.infer<typeof updated>;
+		type Upserted = t.infer<typeof upserted>;
+		type Deleted = t.infer<typeof deleted>;
+
+		const createdCheck: Equal<Created, User> = true;
+		const updatedCheck: Equal<Updated, User> = true;
+		const upsertedCheck: Equal<Upserted, User> = true;
+		const deletedCheck: Equal<Deleted, User> = true;
+
+		expect(createdCheck).toBe(true);
+		expect(updatedCheck).toBe(true);
+		expect(upsertedCheck).toBe(true);
+		expect(deletedCheck).toBe(true);
+		expect(created[__type].validate(alice)).toBe(true);
+		expect(updated[__type].validate(alice)).toBe(true);
+		expect(upserted[__type].validate(alice)).toBe(true);
+		expect(deleted[__type].validate(alice)).toBe(true);
+		expect(created[__type].validate([alice])).toBe(false);
+		expect(updated[__type].validate([alice])).toBe(false);
+		expect(upserted[__type].validate([alice])).toBe(false);
+		expect(deleted[__type].validate([alice])).toBe(false);
+	});
+
+	test("nested record select only() does not add an extra array layer", () => {
+		const query = db
+			.select("post")
+			.return((post) => post.author.select().only());
+		type Result = t.infer<typeof query>;
+
+		const resultCheck: Equal<Result, User[]> = true;
+
+		expect(resultCheck).toBe(true);
+		expect(query[__type].validate([alice])).toBe(true);
+		expect(query[__type].validate([[alice]])).toBe(false);
+	});
+
+	test("only() preserves projection result types in either chain order", () => {
+		const q1 = db
+			.select("user", "alice")
+			.only()
+			.return((u) => ({ name: u.name }));
+		const q2 = db
+			.select("user", "alice")
+			.return((u) => ({ name: u.name }))
+			.only();
+
+		type Q1Result = t.infer<typeof q1>;
+		type Q2Result = t.infer<typeof q2>;
+
+		const q1Check: Equal<Q1Result, { name: string }> = true;
+		const q2Check: Equal<Q2Result, { name: string }> = true;
+
+		expect(q1Check).toBe(true);
+		expect(q2Check).toBe(true);
+		expect(q1[__type].validate({ name: "Alice" })).toBe(true);
+		expect(q2[__type].validate({ name: "Alice" })).toBe(true);
+		expect(q1[__type].validate([{ name: "Alice" }])).toBe(false);
+		expect(q2[__type].validate([{ name: "Alice" }])).toBe(false);
+	});
+
+	test("parseResult uses object shape for only() and array shape by default", () => {
+		expect(db.select("user", "alice").only().parseResult(alice)).toEqual(alice);
+		expect(() =>
+			db.select("user", "alice").only().parseResult([alice]),
+		).toThrow();
+
+		expect(db.create("user", "alice").only().parseResult(alice)).toEqual(alice);
+		expect(() =>
+			db.create("user", "alice").only().parseResult([alice]),
+		).toThrow();
+
+		expect(db.select("user", "alice").parseResult([alice])).toEqual([alice]);
+	});
+
+	test("unsupported builders do not expose only()", () => {
+		const unsupportedTypeAssertions = () => {
+			// @ts-expect-error INSERT does not support ONLY.
+			db.insert("user", { name: "Alice", age: 30 }).only();
+			// @ts-expect-error LIVE SELECT does not support ONLY.
+			db.live("user").only();
+		};
+
+		expect(typeof unsupportedTypeAssertions).toBe("function");
+	});
+});

--- a/tests/unit/utils/workable.test.ts
+++ b/tests/unit/utils/workable.test.ts
@@ -158,19 +158,20 @@ describe("workableGet", () => {
 describe("sanitizeWorkable", () => {
 	test("returns a new object with only workable properties", () => {
 		const ctx = { orm: {} as never, id: Symbol() };
-		const displayFn = () => "test";
 		const type = t.string();
 
 		const input = {
 			[__ctx]: ctx,
-			[__display]: displayFn,
+			[__display](this: { extra: string }) {
+				return this.extra;
+			},
 			[__type]: type,
-			extra: "should not be in output",
+			extra: "test",
 		};
 
 		const result = sanitizeWorkable(input as never);
 		expect(result[__ctx]).toBe(ctx);
-		expect(result[__display]).toBe(displayFn);
+		expect(result[__display](displayContext())).toBe("test");
 		expect(result[__type]).toBe(type);
 		expect((result as Record<string, unknown>).extra).toBeUndefined();
 	});


### PR DESCRIPTION
This PR adds a fluent .only() method to query builders that support SurrealQL’s ONLY clause.

The main goal is to allow single-record queries to return and infer a single object instead of an array, while preserving the existing array behavior by default.

Example:

```js
const users = await db.select("user", "john");
// User[]

const user = await db.select("user", "john").only();
// User
```

This also fixes nested record selections where a linked record currently resolves as an array per parent row:

```js
const authors = await db.select("post").return((post) =>
  post.author.select().only()
);
```

Expected result shape:

User[]

instead of:

User[][]
Supported builders

.only() has been added to the query builders where SurrealQL supports ONLY:

- select
- create
- update
- upsert
- delete
- relate


This feature is fully opt-in.

Existing queries without .only() keep the same runtime behavior and TypeScript inference. In particular, selecting a record by ID still returns an array unless .only() is explicitly used.
