### PR TITLE
Validate bundled type declarations after build (guards against #50)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,9 @@ jobs:
       - name: Run TypeScript type check
         run: bun run type-check
 
+      - name: Build and validate bundled type declarations
+        run: bun run build
+
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
 		"type-check": "tsc --noEmit",
 		"qc": "biome check .",
 		"qa": "biome check . --write",
-		"build": "tsup",
+		"build": "tsup && bun check:dist",
+		"check:dist": "tsc -p tsconfig.dist.json",
 		"prepublishOnly": "bun run build",
 		"qau": "biome check . --write --unsafe"
 	}

--- a/tsconfig.dist.json
+++ b/tsconfig.dist.json
@@ -1,0 +1,14 @@
+{
+	// Validates the bundled declarations that consumers with `skipLibCheck:
+	// false` will parse. The dts bundler rewrites declaration names, so the
+	// emitted files can be invalid even when `src/` type-checks (see #50,
+	// where `t.infer` was flattened into a bare `type infer<T>` reference).
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"skipLibCheck": false,
+		// The dist files import nothing from bun/node; keep runtime type
+		// packages out so their own lib requirements don't fail this check.
+		"types": []
+	},
+	"files": ["dist/index.d.ts", "dist/index.d.cts"]
+}


### PR DESCRIPTION
Fixes #50 (together with a republish).

## What's wrong

The **published** 0.1.0 declarations fail to parse for any consumer running with `skipLibCheck: false`:

```
dist/index.d.ts(1394,56): error TS1003: Identifier expected.
dist/index.d.ts(1394,59): error TS1109: Expression expected.
```

The source is fine — `export type { InferType as infer }` is legal. The bug was introduced by the dts bundler at publish time: it renamed the declaration itself to `infer` and synthesized a bridge alias that references it in a type position, which no TypeScript version (5.0 → 6.0) can parse:

```ts
type infer<T extends AbstractType | Workable> = …;
type t_infer<T extends AbstractType | Workable> = infer<T>;   // ← parse error
```

Rebuilding from the current repo state (tsup 8.5.1 per the lockfile) already emits correct output (`type InferType<…>` + `export { type InferType as infer }`), so **the published artifact just predates the fixed bundler — a rebuild + republish resolves the issue**.

## What this PR adds

Since `src/` type-checking can't catch this class of bug (the bundler rewrites names after the fact), this adds a guard on the emitted files:

- `tsconfig.dist.json` — checks `dist/index.d.ts` and `dist/index.d.cts` with `skipLibCheck: false`, as a strict consumer would see them
- `check:dist` script, run as part of `build` (and therefore `prepublishOnly`, so a broken artifact can't be published)
- CI step in the type-check job

Verified locally: passes on a fresh build; fails with the exact TS1003/TS1109 errors when the published 0.1.0 declarations are dropped into `dist/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
