### PR TITLE
Feat/duration type

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ const user = table("user", {
   age: t.number(),
   isActive: t.bool(),
   created: t.date(),
+  duration: t.duration(),
   userId: t.uuid(),
 
   // Complex objects

--- a/src/schema/orm.ts
+++ b/src/schema/orm.ts
@@ -1,5 +1,5 @@
 import type { SurrealSession } from "surrealdb";
-import { RecordId, type RecordIdValue, Uuid } from "surrealdb";
+import { Duration, RecordId, type RecordIdValue, Uuid } from "surrealdb";
 import { OrmError } from "../error";
 import type { Query } from "../query/abstract";
 import { ApiClient } from "../query/api";
@@ -18,6 +18,7 @@ import {
 	type ArrayType,
 	type BoolType,
 	type DateType,
+	type DurationType,
 	type GraphType,
 	type NeverType,
 	type NoneType,
@@ -115,22 +116,25 @@ export type ValueType<V> =
 						? BoolType
 						: V extends Date
 							? DateType
-							: V extends Uuid
-								? UuidType
-								: V extends null
-									? NullType
-									: V extends undefined
-										? NoneType
-										: V extends readonly unknown[]
-											? ValueArrayType<V>
-											: V extends Record<string, unknown>
-												? ObjectType<ValueObjectFields<V>>
-												: AbstractType;
+							: V extends Duration
+								? DurationType
+								: V extends Uuid
+									? UuidType
+									: V extends null
+										? NullType
+										: V extends undefined
+											? NoneType
+											: V extends readonly unknown[]
+												? ValueArrayType<V>
+												: V extends Record<string, unknown>
+													? ObjectType<ValueObjectFields<V>>
+													: AbstractType;
 
 function typeFromValue(value: unknown): AbstractType {
 	if (isWorkable(value)) return value[__type];
 	if (value instanceof RecordId) return t.record(String(value.table));
 	if (value instanceof Date) return t.date();
+	if (value instanceof Duration) return t.duration();
 	if (value instanceof Uuid) return t.uuid();
 	if (value === null) return t.null();
 	if (value === undefined) return t.none();

--- a/src/types/classes.ts
+++ b/src/types/classes.ts
@@ -160,34 +160,18 @@ export class DateType extends AbstractType<Date> {
 export class DurationType extends AbstractType<Duration> {
 	name = "duration" as const;
 	expected = "Duration";
+
 	validate(value: unknown): value is this["infer"] {
-		// Accept SurrealDB Duration object
-		if (value instanceof Duration) return true;
-		// Check if it's a Duration object from SurrealDB v2
-		return !!(
-			value &&
-			typeof value === "object" &&
-			"toDuration" in value &&
-			typeof (value as Record<string, unknown>).toDuration === "function"
-		);
+		return value instanceof Duration;
 	}
 
 	/**
-	 * Parse a value into a `Duration`, converting SurrealDB `Duration` objects.
+	 * Return an existing SurrealDB `Duration` instance.
 	 *
 	 * @throws {TypeParseError} If `value` is not a `Duration`.
 	 */
 	parse(value: unknown): this["infer"] {
 		if (value instanceof Duration) return value;
-		// Convert DurationTime to Duration if needed
-		if (
-			value &&
-			typeof value === "object" &&
-			"toDuration" in value &&
-			typeof (value as Record<string, unknown>).toDuration === "function"
-		) {
-			return (value as { toDuration: () => Duration }).toDuration();
-		}
 		throw new TypeParseError(this.name, this.expected, value);
 	}
 }

--- a/src/types/classes.ts
+++ b/src/types/classes.ts
@@ -1,4 +1,4 @@
-import { RecordId, Uuid } from "surrealdb";
+import { Duration, RecordId, Uuid } from "surrealdb";
 import { TypeParseError } from "../error";
 
 /** Matches strings usable as a bare SurrealQL identifier in an idiom path. */
@@ -152,6 +152,41 @@ export class DateType extends AbstractType<Date> {
 			typeof (value as Record<string, unknown>).toDate === "function"
 		) {
 			return (value as { toDate: () => Date }).toDate();
+		}
+		throw new TypeParseError(this.name, this.expected, value);
+	}
+}
+
+export class DurationType extends AbstractType<Duration> {
+	name = "duration" as const;
+	expected = "Duration";
+	validate(value: unknown): value is this["infer"] {
+		// Accept SurrealDB Duration object
+		if (value instanceof Duration) return true;
+		// Check if it's a Duration object from SurrealDB v2
+		return !!(
+			value &&
+			typeof value === "object" &&
+			"toDuration" in value &&
+			typeof (value as Record<string, unknown>).toDuration === "function"
+		);
+	}
+
+	/**
+	 * Parse a value into a `Duration`, converting SurrealDB `Duration` objects.
+	 *
+	 * @throws {TypeParseError} If `value` is not a `Duration`.
+	 */
+	parse(value: unknown): this["infer"] {
+		if (value instanceof Duration) return value;
+		// Convert DurationTime to Duration if needed
+		if (
+			value &&
+			typeof value === "object" &&
+			"toDuration" in value &&
+			typeof (value as Record<string, unknown>).toDuration === "function"
+		) {
+			return (value as { toDuration: () => Duration }).toDuration();
 		}
 		throw new TypeParseError(this.name, this.expected, value);
 	}

--- a/src/types/t.ts
+++ b/src/types/t.ts
@@ -4,6 +4,7 @@ import {
 	ArrayType,
 	BoolType,
 	DateType,
+	DurationType,
 	LiteralType,
 	NeverType,
 	NoneType,
@@ -51,6 +52,11 @@ export function never() {
 /** Create a datetime type. */
 export function date() {
 	return new DateType();
+}
+
+/** Create a duration type. */
+export function duration() {
+	return new DurationType();
 }
 
 /** Create a UUID type. */

--- a/tests/unit/schema/orm.test.ts
+++ b/tests/unit/schema/orm.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { Surreal } from "surrealdb";
-import { edge, orm, t, table } from "../../../src";
+import { Duration, Surreal } from "surrealdb";
+import { __type, edge, orm, t, table } from "../../../src";
 
 // Compile-time equality assertion helper.
 type Equal<A, B> =
@@ -101,5 +101,19 @@ describe("orm() object form keeps full type support", () => {
 		const sample: Result = [{ name: "Alice", email: "alice@example.com" }];
 
 		expect(sample[0]?.name).toBe("Alice");
+	});
+});
+
+describe("orm() value inference", () => {
+	test("infers Duration values as duration types", () => {
+		const db = orm(new Surreal(), user);
+		const duration = new Duration("1h");
+		const value = db.value(duration);
+
+		type Value = t.infer<typeof value>;
+		const typed: Value = duration;
+
+		expect(value[__type].name).toBe("duration");
+		expect(typed).toBe(duration);
 	});
 });

--- a/tests/unit/schema/table.test.ts
+++ b/tests/unit/schema/table.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { RecordId } from "surrealdb";
+import { Duration, RecordId } from "surrealdb";
 import { t, table } from "../../../src";
 
 describe("TableSchema", () => {
@@ -149,5 +149,22 @@ describe("TableSchema", () => {
 		};
 
 		expect(post.validate(validRecord)).toBe(true);
+	});
+
+	test("validates duration fields", () => {
+		const task = table("task", { duration: t.duration() });
+
+		expect(
+			task.validate({
+				id: new RecordId("task", "1"),
+				duration: new Duration("1h"),
+			}),
+		).toBe(true);
+		expect(
+			task.validate({
+				id: new RecordId("task", "2"),
+				duration: "1h",
+			}),
+		).toBe(false);
 	});
 });

--- a/tests/unit/types/t.test.ts
+++ b/tests/unit/types/t.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { Duration, RecordId } from "surrealdb";
-import { t } from "../../../src";
+import { DurationType, t } from "../../../src";
 import { TypeParseError } from "../../../src/error";
 import { NoneType, UnionType } from "../../../src/types/classes";
 
@@ -110,6 +110,15 @@ describe("Type builders", () => {
 			expect(type.validate(new Duration("1h"))).toBe(true);
 			expect(type.validate("1h")).toBe(false);
 			expect(type.validate(3600)).toBe(false);
+		});
+
+		test("accepts and preserves Duration instances", () => {
+			const duration = new Duration("1h");
+			const type = new DurationType();
+
+			expect(type.validate(duration)).toBe(true);
+			expect(type.parse(duration)).toBe(duration);
+			expect(t.duration().parse(duration)).toBe(duration);
 		});
 	});
 
@@ -383,12 +392,6 @@ describe("Type builders", () => {
 		test("DurationType.parse() returns Duration passthrough", () => {
 			const duration = new Duration("1h");
 			expect(t.duration().parse(duration)).toBe(duration);
-		});
-
-		test("DurationType.parse() converts object with toDuration()", () => {
-			const duration = new Duration("1h");
-			const result = t.duration().parse({ toDuration: () => duration });
-			expect(result).toBe(duration);
 		});
 
 		test("DurationType.parse() throws for invalid value", () => {

--- a/tests/unit/types/t.test.ts
+++ b/tests/unit/types/t.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { RecordId } from "surrealdb";
+import { Duration, RecordId } from "surrealdb";
 import { t } from "../../../src";
 import { TypeParseError } from "../../../src/error";
 import { NoneType, UnionType } from "../../../src/types/classes";
@@ -95,6 +95,21 @@ describe("Type builders", () => {
 			const type = t.uuid();
 			expect(type).toBeDefined();
 			expect(type.name).toBe("uuid");
+		});
+	});
+
+	describe("duration()", () => {
+		test("creates DurationType", () => {
+			const type = t.duration();
+			expect(type).toBeDefined();
+			expect(type.name).toBe("duration");
+		});
+
+		test("validates Duration values", () => {
+			const type = t.duration();
+			expect(type.validate(new Duration("1h"))).toBe(true);
+			expect(type.validate("1h")).toBe(false);
+			expect(type.validate(3600)).toBe(false);
 		});
 	});
 
@@ -363,6 +378,21 @@ describe("Type builders", () => {
 
 		test("DateType.parse() throws for invalid value", () => {
 			expect(() => t.date().parse("2024-01-01")).toThrow(TypeParseError);
+		});
+
+		test("DurationType.parse() returns Duration passthrough", () => {
+			const duration = new Duration("1h");
+			expect(t.duration().parse(duration)).toBe(duration);
+		});
+
+		test("DurationType.parse() converts object with toDuration()", () => {
+			const duration = new Duration("1h");
+			const result = t.duration().parse({ toDuration: () => duration });
+			expect(result).toBe(duration);
+		});
+
+		test("DurationType.parse() throws for invalid value", () => {
+			expect(() => t.duration().parse("1h")).toThrow(TypeParseError);
 		});
 
 		test("OptionType.parse() returns undefined for absent value", () => {


### PR DESCRIPTION
This pull request adds support for SurrealDB `Duration` types throughout the ORM and type system. The main changes include introducing a new `DurationType` class, updating type inference and value handling to recognize `Duration`, and adding comprehensive tests to ensure correct behavior.

**Duration type support:**

* Added a new `DurationType` class to represent SurrealDB duration values, including validation and parsing logic. (`src/types/classes.ts` [src/types/classes.tsR160-R194](diffhunk://#diff-72af85f90ecbfb245895e2cf153c474c509809d7a661b5e46f11f606697746c3R160-R194))
* Added a `t.duration()` type builder function for easy schema definition. (`src/types/t.ts` [src/types/t.tsR57-R61](diffhunk://#diff-b5f38b9ae8f0eda64c6de2d8d7224424c0f0ec6bec55be9e4774336f2a37b7b2R57-R61))
* Updated the `ValueType` utility and `typeFromValue` function to infer and handle `Duration` values. (`src/schema/orm.ts` [[1]](diffhunk://#diff-6cb230b1b4cf43f5d5412f370cea3a7564ddda3c6ec1ddbb1c398f2ac76a4230R119-R120) [[2]](diffhunk://#diff-6cb230b1b4cf43f5d5412f370cea3a7564ddda3c6ec1ddbb1c398f2ac76a4230R137)

**Schema and ORM integration:**

* Allowed schema definitions (e.g., `table("user", {...})`) to include `duration` fields. (`README.md` [README.mdR115](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R115))
* Updated imports and type handling to support `Duration` in all relevant modules. (`src/schema/orm.ts` [[1]](diffhunk://#diff-6cb230b1b4cf43f5d5412f370cea3a7564ddda3c6ec1ddbb1c398f2ac76a4230L2-R2) [[2]](diffhunk://#diff-6cb230b1b4cf43f5d5412f370cea3a7564ddda3c6ec1ddbb1c398f2ac76a4230R21); `src/types/classes.ts` [[3]](diffhunk://#diff-72af85f90ecbfb245895e2cf153c474c509809d7a661b5e46f11f606697746c3L1-R1); `src/types/t.ts` [[4]](diffhunk://#diff-b5f38b9ae8f0eda64c6de2d8d7224424c0f0ec6bec55be9e4774336f2a37b7b2R7)

**Testing:**

* Added and extended unit tests to verify `DurationType` validation, parsing, and schema integration, including negative cases. (`tests/unit/types/t.test.ts` [[1]](diffhunk://#diff-92cf2ffc423faa7cbcf28bc25f9cfe50e22d6aef1e43c893697788715f1490a1R101-R115) [[2]](diffhunk://#diff-92cf2ffc423faa7cbcf28bc25f9cfe50e22d6aef1e43c893697788715f1490a1R383-R397); `tests/unit/schema/orm.test.ts` [[3]](diffhunk://#diff-06886c956f4eb44ec0f9ef50f22fd01807119882cb8c01918d2c55944bbaf678R106-R119); `tests/unit/schema/table.test.ts` [[4]](diffhunk://#diff-82cc7f32515ad8200c0b6ac3ed7a9ba1e69eab489652651511ee2403ad4ea69fR153-R169)

These changes ensure that duration values are correctly recognized, validated, and used throughout the ORM system.

Close #43