### PR TITLE
Feat/search operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -855,6 +855,9 @@ db.select("user").where((user) =>
   user.age.lt(65)                   // <
   user.age.lte(64)                  // <=
 
+  // Full-text search
+  user.bio.search("typescript")     // @@
+
   // Array membership
   user.status.inside(["active", "pending"])    // IN
   user.status.notInside(["banned", "deleted"]) // NOT IN
@@ -914,6 +917,7 @@ Both `and()` and `or()` require at least two conditions and accept any number of
 
 ```typescript
 db.select("user").where((user) =>
+  user.bio.search("typescript")
   user.email.startsWith("admin@")
   user.name.endsWith("son")
   user.email.contains("@example.com")

--- a/src/functions/filters.ts
+++ b/src/functions/filters.ts
@@ -22,6 +22,7 @@ export const ComparisonKind = t.union([
 	t.literal("*="),
 	t.literal("?~"),
 	t.literal("*~"),
+	t.literal("@@"),
 	t.literal("<"),
 	t.literal("<="),
 	t.literal(">"),
@@ -84,7 +85,9 @@ export function comparingFilter<
 		[__ctx]: ctx,
 		[__type]: t.bool(),
 		[__display](ctx) {
-			return `${l[__display](ctx)} ${kind} ${r[__display](ctx)}`;
+			const left = l[__display](ctx);
+			const field = kind === "@@" ? left.replace(/^\$this\./, "") : left;
+			return `${field} ${kind} ${r[__display](ctx)}`;
 		},
 	});
 }

--- a/src/functions/types/string.ts
+++ b/src/functions/types/string.ts
@@ -13,9 +13,17 @@ import {
 	type WorkableContext,
 } from "../../utils";
 import type { Actionable } from "../../utils/actionable";
+import { comparingFilter } from "../filters";
 import { databaseFunction } from "../utils";
 
 export const functions = {
+	search<C extends WorkableContext>(
+		this: Workable<C, StringType>,
+		value: IntoWorkable<C, StringType>,
+	) {
+		return comparingFilter(this[__ctx], "@@", this, value);
+	},
+
 	startsWith<C extends WorkableContext>(
 		this: Workable<C, StringType>,
 		v: IntoWorkable<C, StringType>,
@@ -521,6 +529,11 @@ export const functions = {
 } satisfies Functions;
 
 export type Functions = {
+	search<C extends WorkableContext>(
+		this: Workable<C, StringType>,
+		value: IntoWorkable<C, StringType>,
+	): Actionable<C, BoolType>;
+
 	startsWith<C extends WorkableContext>(
 		this: Workable<C, StringType>,
 		v: IntoWorkable<C, StringType>,

--- a/tests/integration/queries.test.ts
+++ b/tests/integration/queries.test.ts
@@ -233,6 +233,54 @@ describe("Complex Queries Integration Tests", () => {
 	});
 
 	describe("String functions in queries", () => {
+		test("searches a full-text indexed field with @@", async () => {
+			const { db, surreal } = getTestDb();
+
+			await surreal.query(`
+				DEFINE ANALYZER post_search_analyzer
+					TOKENIZERS blank, class
+					FILTERS lowercase;
+				DEFINE INDEX post_body_search
+					ON TABLE post FIELDS body FULLTEXT ANALYZER post_search_analyzer BM25;
+
+				CREATE post:search_rust SET
+					title = "Rust search",
+					body = "Rust is great for web programming",
+					author = user:alice,
+					created = time::now(),
+					updated = time::now();
+				CREATE post:search_database SET
+					title = "Database search",
+					body = "SurrealDB is a document database",
+					author = user:alice,
+					created = time::now(),
+					updated = time::now();
+				CREATE post:search_unrelated SET
+					title = "Unrelated post",
+					body = "A recipe for vegetable soup",
+					author = user:alice,
+					created = time::now(),
+					updated = time::now();
+			`);
+
+			const rust = await db
+				.select("post")
+				.where((post) => post.body.search("RUST"))
+				.execute();
+			const database = await db
+				.select("post")
+				.where((post) => post.body.search("database"))
+				.execute();
+			const missing = await db
+				.select("post")
+				.where((post) => post.body.search("missing"))
+				.execute();
+
+			expect(rust.map((post) => post.id.id)).toEqual(["search_rust"]);
+			expect(database.map((post) => post.id.id)).toEqual(["search_database"]);
+			expect(missing).toEqual([]);
+		});
+
 		test("uses startsWith in WHERE clause", async () => {
 			const { db } = getTestDb();
 			const result = await db

--- a/tests/unit/functions/string.test.ts
+++ b/tests/unit/functions/string.test.ts
@@ -13,6 +13,16 @@ describe("String functions", () => {
 
 	const db = orm(new Surreal(), user);
 
+	test("search() generates the @@ operator", () => {
+		const query = db
+			.select("user")
+			.where(($this) => $this.email.search("test"));
+		const ctx = displayContext();
+		const result = query[__display](ctx);
+
+		expect(result).toContain("@@");
+	});
+
 	test("join() generates string::join function", () => {
 		const query = db.select("user").return((user) => ({
 			fullName: user.name.first.join(" ", user.name.last),


### PR DESCRIPTION
This pull request adds support for full-text search queries using the `search()` string function, which maps to the SurrealDB `@@` operator. This allows users to perform full-text searches in query filters. The update includes implementation, documentation, and tests to ensure correct behavior.

**Full-text search support:**

* Added a new `search()` string function to the query builder, which generates the `@@` (full-text search) operator in queries. [[1]](diffhunk://#diff-df5b2542d697f44236347ec676598aa36671a0ce0e114ae54aae667075602404R16-R26) [[2]](diffhunk://#diff-df5b2542d697f44236347ec676598aa36671a0ce0e114ae54aae667075602404R532-R536)
* Updated the `comparingFilter` logic to handle the `@@` operator, ensuring the correct field display in generated queries. [[1]](diffhunk://#diff-5b45dd2e2cb75917c18418f3cb1b31162bb8b358c732f838297adc86b6cf2580R25) [[2]](diffhunk://#diff-5b45dd2e2cb75917c18418f3cb1b31162bb8b358c732f838297adc86b6cf2580L87-R90)

**Documentation updates:**

* Documented the usage of the new `search()` function in the `README.md`, including examples in both single and multiple condition queries. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R858-R860) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R920)

**Testing:**

* Added unit and integration tests to verify that the `search()` function generates correct queries and works as expected with full-text indexes. [[1]](diffhunk://#diff-08f83973d115c3a9549194ed37ba8cc8650d3b5ba57abd32ed2b606258a686c6R16-R25) [[2]](diffhunk://#diff-58b5ff659d6748e418cc7c93f5fb6803727303b3081e5f20c0289164dbea8ba1R236-R283)