### PR TITLE
Fold unset() into the SET clause instead of emitting both

### DIFF
--- a/src/query/modification-methods.ts
+++ b/src/query/modification-methods.ts
@@ -130,24 +130,38 @@ export function applyReplace(state: ModificationState, data: unknown): void {
 	state._replace = data;
 }
 
+/**
+ * Render the SET / UNSET data clause.
+ *
+ * An UPDATE takes *either* a SET clause or an UNSET clause — `SET a = 1 UNSET b`
+ * is a parse error ("Unexpected token `UNSET`"). So when a query uses both, the
+ * unsets are folded into the SET clause as `field = NONE`, which is how you
+ * clear a field from inside a SET and is what SurrealDB stores for an absent
+ * `option<T>` anyway.
+ *
+ * `.unset()` on its own still emits a real UNSET clause.
+ */
 function displaySetUnsetClause(
 	state: ModificationState,
 	ctx: DisplayContext,
 ): string {
-	const parts: string[] = [];
+	const unset = state._unset ?? [];
+	const assignments = state._set ? generateSetAssignments(state._set, ctx) : [];
 
-	if (state._set) {
-		const assignments = generateSetAssignments(state._set, ctx);
-		if (assignments.length > 0) {
-			parts.push(`SET ${assignments.join(", ")}`);
+	if (assignments.length > 0) {
+		// NONE is a literal, not a bound value: a parameter bound to `undefined`
+		// is omitted from the payload entirely, which is a different thing.
+		for (const path of unset) {
+			assignments.push(`${escapeIdiomPath(path)} = NONE`);
 		}
+		return ` SET ${assignments.join(", ")}`;
 	}
 
-	if (state._unset && state._unset.length > 0) {
-		parts.push(`UNSET ${state._unset.map(escapeIdiomPath).join(", ")}`);
+	if (unset.length > 0) {
+		return ` UNSET ${unset.map(escapeIdiomPath).join(", ")}`;
 	}
 
-	return parts.length > 0 ? ` ${parts.join(" ")}` : "";
+	return "";
 }
 
 // Helper function to generate modification clause SQL

--- a/tests/unit/query/modification-methods.test.ts
+++ b/tests/unit/query/modification-methods.test.ts
@@ -207,7 +207,9 @@ describe("displayModificationClause", () => {
 		expect(result).toContain("UNSET email, phone");
 	});
 
-	test("renders combined SET and UNSET", () => {
+	test("folds UNSET into SET rather than emitting both clauses", () => {
+		// SurrealQL takes one data clause per UPDATE: `SET a = 1 UNSET b` is a
+		// parse error. Clearing a field from inside a SET is `field = NONE`.
 		const state = createState();
 		applySet(state, { name: "Alice" });
 		applyUnset(state, ["email"]);
@@ -215,7 +217,8 @@ describe("displayModificationClause", () => {
 		const result = displayModificationClause(state, ctx);
 		expect(result).toContain("SET");
 		expect(result).toContain("name =");
-		expect(result).toContain("UNSET email");
+		expect(result).toContain("email = NONE");
+		expect(result).not.toContain("UNSET");
 	});
 
 	test("renders CONTENT clause", () => {

--- a/tests/unit/query/update.test.ts
+++ b/tests/unit/query/update.test.ts
@@ -11,6 +11,26 @@ describe("UPDATE queries", () => {
 
 	const db = orm(new Surreal(), user);
 
+	test("folds unset() into the SET clause instead of emitting both", () => {
+		// `SET a = 1 UNSET b` is a parse error in SurrealQL — an UPDATE takes one
+		// data clause or the other. Clearing a field from inside a SET is `= NONE`.
+		const query = db.update("user").set({ age: 30 }).unset(["email"]);
+		const ctx = displayContext();
+		const result = query[__display](ctx);
+
+		expect(result).not.toContain("UNSET");
+		expect(result).toContain("email = NONE");
+		expect(result).toMatch(/SET age = \$_v\d+, email = NONE/);
+	});
+
+	test("unset() on its own still emits an UNSET clause", () => {
+		const query = db.update("user").unset(["email", "name"]);
+		const ctx = displayContext();
+		const result = query[__display](ctx);
+
+		expect(result).toBe("(UPDATE $_v0 UNSET email, name)");
+	});
+
 	test("generates bulk UPDATE with SET", () => {
 		const query = db.update("user").set({
 			age: 30,


### PR DESCRIPTION
Closes #56.

`db.update("u").set({ a: 1 }).unset(["b"])` rendered

    UPDATE u SET a = $_v0 UNSET b

which SurrealDB rejects — an `UPDATE` takes one data clause, not two.

Clearing a field from inside a `SET` is `field = NONE`, so the unsets now fold in there when both are present. `.unset()` on its own still emits a real `UNSET` clause, which was always valid.

`NONE` is emitted as a literal rather than a bound parameter. A parameter bound to `undefined` is omitted from the CBOR payload, which is a different thing from assigning `NONE` — the field would keep its old value instead of being cleared.

## The part worth more than the fix

The combination was never executable, and the test covering it was green the whole time:

```ts
expect(query[__display](ctx)).toBe("UPDATE u SET a = $_v0 UNSET b");
```

It asserted the rendered string and never ran it. Anything that builds a query language probably wants at least one path that executes what it renders — `tests/unit/query/update.test.ts` now covers the fold, but the general point is worth more than this instance.

## Testing

`bun run qc`, `bun run type-check`, and `bun test tests/unit/` all clean.