### PR TITLE
Feat/geometry point support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1062,6 +1062,34 @@ type Result = t.infer<typeof query>;
 // }>
 ```
 
+## Geospatial points
+
+```typescript
+import { GeometryPoint, Surreal } from "surrealdb";
+import { geo, orm, table, t, type_ } from "surqlize";
+
+const place = table("place", {
+  location: t.point(),
+  coordinates: t.array([t.number(), t.number()]),
+});
+const db = orm(new Surreal(), place);
+
+const center = new GeometryPoint([12.5, 41.9]);
+const nearby = db.select("place").where((place) =>
+  geo.distance(place.location, center).lt(5000),
+);
+const nearbyByCoordinates = db.select("place").where((place) =>
+  geo.distance(place.coordinates, [12.5, 41.9]).lt(5000),
+);
+```
+
+`t.point()` describes a native SurrealDB point value. For raw coordinate data,
+use `t.array([t.number(), t.number()])`. `type_.point(value)` explicitly emits
+`type::point(value)`, while `geo.distance()` automatically accepts a
+`GeometryPoint` or `[longitude, latitude]` and performs required coordinate
+casts in SurrealDB. Distances are returned by SurrealDB in metres. Coordinates
+are always ordered longitude first, latitude second.
+
 ## Standalone functions
 
 Standalone functions are not called on a field but used independently within query callbacks. Functions with value parameters extract the query context automatically from the first value. Zero-arg functions and constants require an explicit context source (any `Workable` from the callback).

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -15,6 +15,7 @@ const functions = {
 	graph: typeFunctions.graph.functions,
 	number: typeFunctions.number.functions,
 	option: typeFunctions.option.functions,
+	point: {},
 	record: typeFunctions.record.functions,
 	string: typeFunctions.string.functions,
 } satisfies BaseFunctions;
@@ -26,6 +27,7 @@ interface BaseFunctions {
 	graph: typeFunctions.graph.Functions;
 	number: typeFunctions.number.Functions;
 	option: typeFunctions.option.Functions;
+	point: object;
 	record: typeFunctions.record.Functions;
 	string: typeFunctions.string.Functions;
 }

--- a/src/functions/standalone/geo.ts
+++ b/src/functions/standalone/geo.ts
@@ -1,6 +1,65 @@
-import { t } from "../../types";
-import type { Workable, WorkableContext } from "../../utils";
+import { GeometryPoint } from "surrealdb";
+import {
+	type AbstractType,
+	ArrayType,
+	NumberType,
+	PointType,
+	t,
+} from "../../types";
+import {
+	__ctx,
+	__type,
+	intoWorkable,
+	isWorkable,
+	type Workable,
+	type WorkableContext,
+} from "../../utils";
 import { standaloneFn } from "./internal";
+
+type CoordinateType = ArrayType<[NumberType, NumberType]>;
+type PointExpression<C extends WorkableContext> = Workable<
+	C,
+	PointType | CoordinateType
+>;
+type Coordinate = readonly [number, number];
+type PointArgument<C extends WorkableContext> =
+	| PointExpression<C>
+	| GeometryPoint
+	| Coordinate;
+type DistanceArguments<C extends WorkableContext> =
+	| [p1: PointExpression<C>, p2: PointArgument<C>]
+	| [p1: GeometryPoint | Coordinate, p2: PointExpression<C>];
+
+function isCoordinateType(type: AbstractType): type is CoordinateType {
+	return (
+		type instanceof ArrayType &&
+		Array.isArray(type.schema) &&
+		type.schema.length === 2 &&
+		type.schema.every((item) => item instanceof NumberType)
+	);
+}
+
+function normalizePoint<C extends WorkableContext>(
+	source: PointExpression<C>,
+	value: PointArgument<C>,
+): Workable<C, PointType> {
+	if (isWorkable(value)) {
+		if (value[__type] instanceof PointType)
+			return value as Workable<C, PointType>;
+		if (isCoordinateType(value[__type]))
+			return standaloneFn(value, t.point(), "type::point", value);
+	}
+
+	if (value instanceof GeometryPoint)
+		return intoWorkable(source[__ctx], t.point(), value);
+
+	const coordinates = intoWorkable(
+		source[__ctx],
+		t.array([t.number(), t.number()]),
+		value as [number, number],
+	);
+	return standaloneFn(source, t.point(), "type::point", coordinates);
+}
 
 export const geo = {
 	area<C extends WorkableContext>(value: Workable<C>) {
@@ -12,8 +71,15 @@ export const geo = {
 	centroid<C extends WorkableContext>(value: Workable<C>) {
 		return standaloneFn(value, t.string(), "geo::centroid", value);
 	},
-	distance<C extends WorkableContext>(p1: Workable<C>, p2: Workable<C>) {
-		return standaloneFn(p1, t.number(), "geo::distance", p1, p2);
+	// Point normalization is intentionally limited to distance; the other geo
+	// functions retain their existing generic signatures until their point types
+	// are specified.
+	distance<C extends WorkableContext>(...args: DistanceArguments<C>) {
+		const [p1, p2] = args;
+		const source = (isWorkable(p1) ? p1 : p2) as PointExpression<C>;
+		const point1 = normalizePoint(source, p1);
+		const point2 = normalizePoint(source, p2);
+		return standaloneFn(point1, t.number(), "geo::distance", point1, point2);
 	},
 	hashDecode<C extends WorkableContext>(value: Workable<C>) {
 		return standaloneFn(value, t.string(), "geo::hash::decode", value);

--- a/src/functions/standalone/type.ts
+++ b/src/functions/standalone/type.ts
@@ -24,6 +24,9 @@ export const type_ = {
 	int<C extends WorkableContext>(value: Workable<C>) {
 		return standaloneFn(value, t.number(), "type::int", value);
 	},
+	point<C extends WorkableContext>(value: Workable<C>) {
+		return standaloneFn(value, t.point(), "type::point", value);
+	},
 	number<C extends WorkableContext>(value: Workable<C>) {
 		return standaloneFn(value, t.number(), "type::number", value);
 	},

--- a/src/schema/orm.ts
+++ b/src/schema/orm.ts
@@ -1,10 +1,5 @@
 import type { SurrealSession } from "surrealdb";
-import {
-	GeometryPoint,
-	RecordId,
-	type RecordIdValue,
-	Uuid,
-} from "surrealdb";
+import { GeometryPoint, RecordId, type RecordIdValue, Uuid } from "surrealdb";
 import { OrmError } from "../error";
 import type { Query } from "../query/abstract";
 import { ApiClient } from "../query/api";

--- a/src/schema/orm.ts
+++ b/src/schema/orm.ts
@@ -1,5 +1,10 @@
 import type { SurrealSession } from "surrealdb";
-import { RecordId, type RecordIdValue, Uuid } from "surrealdb";
+import {
+	GeometryPoint,
+	RecordId,
+	type RecordIdValue,
+	Uuid,
+} from "surrealdb";
 import { OrmError } from "../error";
 import type { Query } from "../query/abstract";
 import { ApiClient } from "../query/api";
@@ -24,6 +29,7 @@ import {
 	type NullType,
 	type NumberType,
 	type ObjectType,
+	type PointType,
 	type RecordType,
 	type StringType,
 	t,
@@ -117,21 +123,24 @@ export type ValueType<V> =
 							? DateType
 							: V extends Uuid
 								? UuidType
-								: V extends null
-									? NullType
-									: V extends undefined
-										? NoneType
-										: V extends readonly unknown[]
-											? ValueArrayType<V>
-											: V extends Record<string, unknown>
-												? ObjectType<ValueObjectFields<V>>
-												: AbstractType;
+								: V extends GeometryPoint
+									? PointType
+									: V extends null
+										? NullType
+										: V extends undefined
+											? NoneType
+											: V extends readonly unknown[]
+												? ValueArrayType<V>
+												: V extends Record<string, unknown>
+													? ObjectType<ValueObjectFields<V>>
+													: AbstractType;
 
 function typeFromValue(value: unknown): AbstractType {
 	if (isWorkable(value)) return value[__type];
 	if (value instanceof RecordId) return t.record(String(value.table));
 	if (value instanceof Date) return t.date();
 	if (value instanceof Uuid) return t.uuid();
+	if (value instanceof GeometryPoint) return t.point();
 	if (value === null) return t.null();
 	if (value === undefined) return t.none();
 

--- a/src/types/classes.ts
+++ b/src/types/classes.ts
@@ -1,4 +1,4 @@
-import { RecordId, Uuid } from "surrealdb";
+import { GeometryPoint, RecordId, Uuid } from "surrealdb";
 import { TypeParseError } from "../error";
 
 /** Matches strings usable as a bare SurrealQL identifier in an idiom path. */
@@ -157,6 +157,14 @@ export class DateType extends AbstractType<Date> {
 	}
 }
 
+export class PointType extends AbstractType<GeometryPoint> {
+	name = "point" as const;
+	expected = "GeometryPoint";
+
+	validate(value: unknown): value is this["infer"] {
+		return value instanceof GeometryPoint;
+	}
+}
 export class UuidType extends AbstractType<Uuid> {
 	name = "uuid" as const;
 	expected = "Uuid";

--- a/src/types/t.ts
+++ b/src/types/t.ts
@@ -11,6 +11,7 @@ import {
 	NumberType,
 	ObjectType,
 	OptionType,
+	PointType,
 	RecordType,
 	StringType,
 	UnionType,
@@ -53,6 +54,10 @@ export function date() {
 	return new DateType();
 }
 
+/** Create a native SurrealDB point type. */
+export function point() {
+	return new PointType();
+}
 /** Create a UUID type. */
 export function uuid() {
 	return new UuidType();

--- a/tests/integration/functions.test.ts
+++ b/tests/integration/functions.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { fn, TypeParseError, t } from "../../src";
+import { GeometryPoint } from "surrealdb";
+import { fn, geo, orm, TypeParseError, t, table } from "../../src";
 import { withTestDb } from "./setup";
+
+const location = table("location", {
+	point: t.point(),
+});
 
 describe("User-defined function integration tests", () => {
 	const getTestDb = withTestDb({ perTest: true });
@@ -144,6 +149,29 @@ describe("User-defined function integration tests", () => {
 			expect(result).toHaveLength(2);
 			const names = result.map((r) => r.name.first).sort();
 			expect(names).toEqual(["Alice", "Charlie"]);
+		});
+	});
+
+	describe("geo.distance()", () => {
+		test("executes native and coordinate tuple point distances", async () => {
+			const { surreal } = getTestDb();
+			const db = orm(surreal, location);
+			const origin = new GeometryPoint([12.5, 41.9]);
+
+			await db.create("location", "rome").set({ point: origin }).execute();
+
+			const result = await db
+				.select("location")
+				.return((loc) => ({
+					native: geo.distance(loc.point, origin),
+					tuple: geo.distance(loc.point, [12.5, 41.95]),
+				}))
+				.execute();
+
+			expect(result).toHaveLength(1);
+			expect(result[0]!.native).toBe(0);
+			expect(result[0]!.tuple).toBeGreaterThan(5000);
+			expect(result[0]!.tuple).toBeLessThan(6000);
 		});
 	});
 

--- a/tests/unit/functions/geo.test.ts
+++ b/tests/unit/functions/geo.test.ts
@@ -95,10 +95,16 @@ describe("Geo functions", () => {
 
 	test("rejects non-coordinate distance arguments at compile time", () => {
 		// Coordinates are always [longitude, latitude], never arbitrary arrays.
-		// @ts-expect-error A three-number array is not a point tuple.
-		geo.distance(db.select("location").wrap(), [1, 2, 3]);
-		// @ts-expect-error A one-number array is not a point tuple.
-		geo.distance(db.select("location").wrap(), [1]);
+		db.select("location").where((loc) => {
+			// @ts-expect-error A three-number array is not a point tuple.
+			geo.distance(loc.point, [1, 2, 3]);
+			return loc.name.eq("test");
+		});
+		db.select("location").where((loc) => {
+			// @ts-expect-error A one-number array is not a point tuple.
+			geo.distance(loc.point, [1]);
+			return loc.name.eq("test");
+		});
 		// @ts-expect-error A complete row is not a point expression.
 		db.select("location").where((loc) => geo.distance(loc, [1, 2]));
 		// @ts-expect-error Raw values need a workable argument to provide context.

--- a/tests/unit/functions/geo.test.ts
+++ b/tests/unit/functions/geo.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, test } from "bun:test";
-import { Surreal } from "surrealdb";
+import { GeometryPoint, Surreal } from "surrealdb";
 import { __display, displayContext, geo, orm, t, table } from "../../../src";
 
 describe("Geo functions", () => {
 	const location = table("location", {
 		name: t.string(),
 		coords: t.string(),
+		point: t.point(),
+		coordinates: t.array([t.number(), t.number()]),
 		area: t.string(),
 	});
 
@@ -43,12 +45,64 @@ describe("Geo functions", () => {
 
 	test("geo.distance() generates geo::distance", () => {
 		const query = db.select("location").return((loc) => ({
-			dist: geo.distance(loc.coords, loc.coords),
+			dist: geo.distance(loc.point, new GeometryPoint([10, 20])),
 		}));
 		const ctx = displayContext();
 		const result = query[__display](ctx);
 
 		expect(result).toContain("geo::distance");
+	});
+
+	test("keeps native points unchanged and binds GeometryPoint values", () => {
+		const center = new GeometryPoint([12.5, 41.9]);
+		const query = db
+			.select("location")
+			.where((loc) => geo.distance(loc.point, center).lt(5000));
+		const ctx = displayContext();
+		const result = query[__display](ctx);
+
+		expect(result).toBe(
+			"(SELECT * FROM $_v0 WHERE geo::distance($this.point, $_v1) < $_v2)",
+		);
+		expect(ctx.variables._v1).toBe(center);
+		expect(ctx.variables._v2).toBe(5000);
+	});
+
+	test("casts raw coordinate tuples to points", () => {
+		const query = db
+			.select("location")
+			.where((loc) => geo.distance(loc.point, [12.5, 41.9]).lt(5000));
+		const ctx = displayContext();
+		const result = query[__display](ctx);
+
+		expect(result).toBe(
+			"(SELECT * FROM $_v0 WHERE geo::distance($this.point, type::point($_v1)) < $_v2)",
+		);
+		expect(ctx.variables._v1).toEqual([12.5, 41.9]);
+	});
+
+	test("casts coordinate expressions and raw tuples to points", () => {
+		const query = db
+			.select("location")
+			.where((loc) => geo.distance(loc.coordinates, [12.5, 41.9]).lt(5000));
+		const ctx = displayContext();
+		const result = query[__display](ctx);
+
+		expect(result).toBe(
+			"(SELECT * FROM $_v0 WHERE geo::distance(type::point($this.coordinates), type::point($_v1)) < $_v2)",
+		);
+	});
+
+	test("rejects non-coordinate distance arguments at compile time", () => {
+		// Coordinates are always [longitude, latitude], never arbitrary arrays.
+		// @ts-expect-error A three-number array is not a point tuple.
+		geo.distance(db.select("location").wrap(), [1, 2, 3]);
+		// @ts-expect-error A one-number array is not a point tuple.
+		geo.distance(db.select("location").wrap(), [1]);
+		// @ts-expect-error A complete row is not a point expression.
+		db.select("location").where((loc) => geo.distance(loc, [1, 2]));
+		// @ts-expect-error Raw values need a workable argument to provide context.
+		geo.distance(new GeometryPoint([1, 2]), [3, 4]);
 	});
 
 	test("geo.hashDecode() generates geo::hash::decode", () => {

--- a/tests/unit/functions/geo.test.ts
+++ b/tests/unit/functions/geo.test.ts
@@ -111,6 +111,18 @@ describe("Geo functions", () => {
 		geo.distance(new GeometryPoint([1, 2]), [3, 4]);
 	});
 
+	test("rejects unsupported point methods at compile time", () => {
+		// Never invoked; present only so `tsc` checks the @ts-expect-error case.
+		const _typeErrors = () => {
+			db.select("location").return((loc) => {
+				// @ts-expect-error Point expressions expose only generic functions.
+				loc.point.thisMethodDoesNotExist();
+				return loc.point;
+			});
+		};
+		expect(typeof _typeErrors).toBe("function");
+	});
+
 	test("geo.hashDecode() generates geo::hash::decode", () => {
 		const query = db.select("location").return((loc) => ({
 			decoded: geo.hashDecode(loc.coords),

--- a/tests/unit/functions/type.test.ts
+++ b/tests/unit/functions/type.test.ts
@@ -14,6 +14,7 @@ describe("Type functions", () => {
 		age: t.number(),
 		email: t.string(),
 		created: t.date(),
+		coordinates: t.array([t.number(), t.number()]),
 	});
 
 	const db = orm(new Surreal(), user);
@@ -36,5 +37,15 @@ describe("Type functions", () => {
 		const result = query[__display](ctx);
 
 		expect(result).toContain("type::of");
+	});
+
+	test("type_.point() generates type::point", () => {
+		const query = db.select("user").return((user) => ({
+			point: typeFn.point(user.coordinates),
+		}));
+		const ctx = displayContext();
+		const result = query[__display](ctx);
+
+		expect(result).toContain("type::point($this.coordinates)");
 	});
 });

--- a/tests/unit/schema/orm.test.ts
+++ b/tests/unit/schema/orm.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, test } from "bun:test";
-import { Surreal } from "surrealdb";
-import { edge, orm, t, table } from "../../../src";
+import { GeometryPoint, Surreal } from "surrealdb";
+import {
+	__display,
+	__type,
+	displayContext,
+	edge,
+	orm,
+	PointType,
+	t,
+	table,
+} from "../../../src";
 
 // Compile-time equality assertion helper.
 type Equal<A, B> =
@@ -101,5 +110,21 @@ describe("orm() object form keeps full type support", () => {
 		const sample: Result = [{ name: "Alice", email: "alice@example.com" }];
 
 		expect(sample[0]?.name).toBe("Alice");
+	});
+});
+describe("orm() value inference", () => {
+	test("infers and binds GeometryPoint values as points", () => {
+		const db = orm(new Surreal(), user);
+		const point = new GeometryPoint([10, 20]);
+		const value = db.value(point);
+		const ctx = displayContext();
+
+		type Value = t.infer<typeof value>;
+		const typed: Value = point;
+
+		expect(value[__type]).toBeInstanceOf(PointType);
+		expect(value[__display](ctx)).toBe("$_v0");
+		expect(ctx.variables._v0).toBe(point);
+		expect(typed).toBe(point);
 	});
 });

--- a/tests/unit/types/t.test.ts
+++ b/tests/unit/types/t.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { RecordId } from "surrealdb";
+import { GeometryPoint, RecordId } from "surrealdb";
 import { t } from "../../../src";
 import { TypeParseError } from "../../../src/error";
 import { NoneType, UnionType } from "../../../src/types/classes";
@@ -98,6 +98,21 @@ describe("Type builders", () => {
 		});
 	});
 
+	describe("point()", () => {
+		test("creates PointType", () => {
+			const type = t.point();
+			expect(type).toBeDefined();
+			expect(type.name).toBe("point");
+			expect(type.expected).toBe("GeometryPoint");
+		});
+
+		test("validates GeometryPoint values", () => {
+			const type = t.point();
+			expect(type.validate(new GeometryPoint([10, 20]))).toBe(true);
+			expect(type.validate([10, 20])).toBe(false);
+			expect(type.validate({ point: [10, 20] })).toBe(false);
+		});
+	});
 	describe("object()", () => {
 		test("creates ObjectType with schema", () => {
 			const type = t.object({
@@ -500,6 +515,14 @@ describe("Type builders", () => {
 			expect(arrayType).toBeDefined();
 			expect(unionType).toBeDefined();
 			expect(optionType).toBeDefined();
+		});
+
+		test("infers GeometryPoint from point()", () => {
+			const pointType = t.point();
+			type Point = t.infer<typeof pointType>;
+			const point: Point = new GeometryPoint([10, 20]);
+
+			expect(point).toBeInstanceOf(GeometryPoint);
 		});
 	});
 });


### PR DESCRIPTION
This pull request adds comprehensive support for geospatial point types, specifically SurrealDB's native `GeometryPoint`, throughout the ORM, type system, and query builder. It introduces a new `PointType`, updates type inference and value handling to recognize and bind `GeometryPoint` values, and enhances the `geo.distance()` and `type_.point()` functions for seamless use with both native points and coordinate arrays. Extensive tests and documentation are included to ensure correct usage and developer clarity.

**Geospatial Point Type Support**

* Added a new `PointType` class and the `t.point()` type builder for native SurrealDB geospatial points, including type inference and validation for `GeometryPoint` values. (`src/types/classes.ts` [[1]](diffhunk://#diff-72af85f90ecbfb245895e2cf153c474c509809d7a661b5e46f11f606697746c3R160-R167) `src/types/t.ts` [[2]](diffhunk://#diff-b5f38b9ae8f0eda64c6de2d8d7224424c0f0ec6bec55be9e4774336f2a37b7b2R57-R60) [[3]](diffhunk://#diff-92cf2ffc423faa7cbcf28bc25f9cfe50e22d6aef1e43c893697788715f1490a1R101-R115) [[4]](diffhunk://#diff-92cf2ffc423faa7cbcf28bc25f9cfe50e22d6aef1e43c893697788715f1490a1R519-R526)
* Updated the ORM and type inference system to recognize and handle `GeometryPoint` as a first-class value type, enabling automatic binding and correct query serialization. (`src/schema/orm.ts` [[1]](diffhunk://#diff-6cb230b1b4cf43f5d5412f370cea3a7564ddda3c6ec1ddbb1c398f2ac76a4230L2-R2) [[2]](diffhunk://#diff-6cb230b1b4cf43f5d5412f370cea3a7564ddda3c6ec1ddbb1c398f2ac76a4230R27) [[3]](diffhunk://#diff-6cb230b1b4cf43f5d5412f370cea3a7564ddda3c6ec1ddbb1c398f2ac76a4230R121-R122) [[4]](diffhunk://#diff-6cb230b1b4cf43f5d5412f370cea3a7564ddda3c6ec1ddbb1c398f2ac76a4230R138) `tests/unit/schema/orm.test.ts` [[5]](diffhunk://#diff-06886c956f4eb44ec0f9ef50f22fd01807119882cb8c01918d2c55944bbaf678R115-R130)

**Query Functions and Expression Handling**

* Enhanced `geo.distance()` to accept `GeometryPoint` values, coordinate arrays, and point expressions interchangeably, with automatic casting and normalization for SurrealDB queries. (`src/functions/standalone/geo.ts` [[1]](diffhunk://#diff-48a2213c03cb6678ad296f19fc5ec99f39ed229a9820ab3149d01f22452b6dd3L1-R63) [[2]](diffhunk://#diff-48a2213c03cb6678ad296f19fc5ec99f39ed229a9820ab3149d01f22452b6dd3L15-R82) `README.md` [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1065-R1092)
* Added `type_.point()` to explicitly cast values to SurrealDB point types in queries. (`src/functions/standalone/type.ts` [[1]](diffhunk://#diff-b6bf6c7dcf354a883d61d3ae38d5ace80ba423071d9415a0340c8dbf6c0bc78eR27-R29) `tests/unit/functions/type.test.ts` [[2]](diffhunk://#diff-f03609c5a87a0e907f6b2008cb4541719ae10f7222d4e72964d5ad5c1a0b45a3R41-R50)

**Documentation and Testing**

* Expanded documentation with a new section on geospatial points, usage examples, and clear guidance on coordinate ordering and type distinctions. (`README.md` [README.mdR1065-R1092](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1065-R1092))
* Added extensive unit tests for point type creation, value inference, function usage, and compile-time safety for invalid geospatial arguments. (`tests/unit/functions/geo.test.ts` [[1]](diffhunk://#diff-975a85fd92c2457de9bb25a430fa023995066462571c3d13feb6cd82f9c943c6L46-R113) `tests/unit/types/t.test.ts` [[2]](diffhunk://#diff-92cf2ffc423faa7cbcf28bc25f9cfe50e22d6aef1e43c893697788715f1490a1R101-R115) [[3]](diffhunk://#diff-92cf2ffc423faa7cbcf28bc25f9cfe50e22d6aef1e43c893697788715f1490a1R519-R526) `tests/unit/schema/orm.test.ts` [[4]](diffhunk://#diff-06886c956f4eb44ec0f9ef50f22fd01807119882cb8c01918d2c55944bbaf678R115-R130) `tests/unit/functions/type.test.ts` [[5]](diffhunk://#diff-f03609c5a87a0e907f6b2008cb4541719ae10f7222d4e72964d5ad5c1a0b45a3R41-R50)

These changes ensure robust, type-safe handling of geospatial data in the ORM and query builder, streamlining development of location-aware applications.